### PR TITLE
Release v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.4] - 2025-07-08
+
+### Changed
+- Added `Prompt.from_path()` convenience constructor.
+- Cleaned up `Prompt` initialization logic and updated docs.
+
 ## [0.0.1] - 2025-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 > **So simple, it's not even worth vibing about coding yet it just makes so much sense.**
 
-Are you tired of vendors trying to sell you fancy UIs for prompt management that just make your system more confusing and harder to debug? Isn't it nice to just have your prompts **next to your code**? 
+Are you tired of vendors trying to sell you fancy UIs for prompt management that just make your system more confusing and harder to debug? Isn't it nice to just have your prompts **next to your code**?
 
 But then you worry: *Did my formatter change my prompt? Are those spaces at the beginning actually part of the prompt or just indentation?*
 
@@ -18,7 +18,7 @@ But then you worry: *Did my formatter change my prompt? Are those spaces at the 
 ## Why textprompts?
 
 - ✅ **Prompts live next to your code** - no external systems to manage
-- ✅ **Git is your version control** - diff, branch, and experiment with ease  
+- ✅ **Git is your version control** - diff, branch, and experiment with ease
 - ✅ **No formatter headaches** - your prompts stay exactly as you wrote them
 - ✅ **Minimal markup** - just TOML front-matter when you need metadata (or no metadata if you prefer!)
 - ✅ **Zero dependencies** - well, almost (just Pydantic)
@@ -57,12 +57,12 @@ import textprompts
 # Just load it - works with or without metadata
 prompt = textprompts.load_prompt("greeting.txt")
 # Or simply
-alt = textprompts.Prompt("greeting.txt")
+alt = textprompts.Prompt.from_path("greeting.txt")
 
 # Use it safely - all placeholders must be provided
 message = prompt.prompt.format(
     customer_name="Alice",
-    company_name="ACME Corp", 
+    company_name="ACME Corp",
     issue_type="billing question",
     agent_name="Sarah"
 )
@@ -145,7 +145,7 @@ prompt = textprompts.load_prompt("prompt.txt")  # No metadata parsing
 print(prompt.meta.title)  # "prompt" (from filename)
 
 # 2. ALLOW: Load metadata if present, don't worry if it's incomplete
-textprompts.set_metadata("allow")  # Flexible metadata loading  
+textprompts.set_metadata("allow")  # Flexible metadata loading
 prompt = textprompts.load_prompt("prompt.txt")  # Loads any metadata found
 
 # 3. STRICT: Require complete metadata for production use
@@ -158,7 +158,7 @@ prompt = textprompts.load_prompt("prompt.txt", meta="strict")
 
 **Why this design?**
 - **Default = Simple**: No configuration needed, just load files
-- **Flexible**: Add metadata when you want structure  
+- **Flexible**: Add metadata when you want structure
 - **Production-Safe**: Use strict mode to catch missing metadata before deployment
 
 ## Real-World Examples
@@ -183,7 +183,7 @@ response = openai.chat.completions.create(
             )
         },
         {
-            "role": "user", 
+            "role": "user",
             "content": user_prompt.prompt.format(
                 query="How do I return an item?",
                 customer_tier="premium"
@@ -217,7 +217,7 @@ description = "Search our product catalog"
                     "description": "Search query for products"
                 },
                 "category": {
-                    "type": "string", 
+                    "type": "string",
                     "enum": ["electronics", "clothing", "books"],
                     "description": "Product category to search within"
                 },
@@ -299,7 +299,7 @@ Use {variables} for templating.
 Choose the right level of strictness for your use case:
 
 1. **IGNORE** (default) - Simple text file loading, filename becomes title
-2. **ALLOW** - Load metadata if present, don't worry about completeness  
+2. **ALLOW** - Load metadata if present, don't worry about completeness
 3. **STRICT** - Require complete metadata (title, description, version) for production safety
 
 You can also set the environment variable `TEXTPROMPTS_METADATA_MODE` to one of
@@ -309,7 +309,7 @@ default mode.
 ```python
 # Set globally
 textprompts.set_metadata("ignore")   # Default: simple file loading
-textprompts.set_metadata("allow")    # Flexible: load any metadata  
+textprompts.set_metadata("allow")    # Flexible: load any metadata
 textprompts.set_metadata("strict")   # Production: require complete metadata
 
 # Or override per prompt
@@ -387,7 +387,7 @@ template = PromptString("Hello {name}, you are {role}")
 result = template.format(name="Alice", role="admin")  # ✅ Works
 result = template.format(name="Alice")  # ❌ Raises ValueError
 
-# Partial formatting - replace only available placeholders  
+# Partial formatting - replace only available placeholders
 partial = template.format(name="Alice", skip_validation=True)  # ✅ "Hello Alice, you are {role}"
 
 # Access placeholder information

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -94,7 +94,7 @@ Represents a loaded prompt with metadata and content.
 ```python
 prompt = load_prompt("example.txt")
 # or
-prompt = Prompt("example.txt")
+prompt = Prompt.from_path("example.txt")
 print(prompt.path)  # PosixPath('example.txt')
 print(prompt.meta.title)  # "Example Prompt"
 print(prompt.prompt)  # PromptString("Hello {name}!")
@@ -142,7 +142,7 @@ print(template.placeholders)  # {'name', 'age'}
 # ✅ Strict formatting (default) - all placeholders required
 result = template.format(name="Alice", age=30)
 
-# ❌ This raises ValueError  
+# ❌ This raises ValueError
 result = template.format(name="Alice")  # Missing 'age'
 
 # ✅ Partial formatting with skip_validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "textprompts"
-version = "0.0.3"
+version = "0.0.4"
 description = "Minimal text-based prompt-loader with TOML front-matter"
 readme = "README.md"
 license = "MIT"
@@ -60,6 +60,7 @@ ignore = ["E501"]  # Ignore line length
 [tool.mypy]
 python_version = "3.11"
 strict = true
+mypy_path = "src"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/src/textprompts/models.py
+++ b/src/textprompts/models.py
@@ -21,22 +21,14 @@ class Prompt(BaseModel):
     meta: Union[PromptMeta, None]
     prompt: PromptString
 
-    def __init__(
-        self,
-        path: Union[str, Path],
-        meta: Union[PromptMeta, MetadataMode, str, None] = None,
-        prompt: Union[str, PromptString, None] = None,
-    ) -> None:
-        """Initialize Prompt from fields or load from file."""
-        if prompt is None:
-            from .loaders import load_prompt
+    @classmethod
+    def from_path(
+        cls, path: Union[str, Path], *, meta: Union[MetadataMode, str, None] = None
+    ) -> "Prompt":
+        """Load a Prompt from ``path`` using ``load_prompt``."""
+        from .loaders import load_prompt
 
-            loaded = load_prompt(path, meta=meta)
-            super().__init__(**loaded.model_dump())
-        else:
-            if isinstance(prompt, str):
-                prompt = PromptString(prompt)
-            super().__init__(path=Path(path), meta=meta, prompt=prompt)
+        return load_prompt(path, meta=meta)
 
     @field_validator("prompt")
     @classmethod

--- a/tests/test_prompt_constructor.py
+++ b/tests/test_prompt_constructor.py
@@ -1,22 +1,24 @@
 import importlib
 from pathlib import Path
 
+import pytest  # type: ignore
+
 from textprompts.models import Prompt
 
 
 def test_prompt_init_loads_file(fixtures: Path) -> None:
-    p = Prompt(fixtures / "no_meta.txt", meta="ignore")
+    p = Prompt.from_path(fixtures / "no_meta.txt", meta="ignore")
     assert p.meta and p.meta.title == "no_meta"
     assert "plain text" in p.prompt
 
 
 def test_prompt_init_with_metadata_mode(fixtures: Path) -> None:
-    p = Prompt(fixtures / "good.txt", meta="allow")
+    p = Prompt.from_path(fixtures / "good.txt", meta="allow")
     assert p.meta and p.meta.title == "Example"
     assert "Hello" in p.prompt
 
 
-def test_env_var_overrides(monkeypatch):
+def test_env_var_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEXTPROMPTS_METADATA_MODE", "strict")
     cfg = importlib.reload(importlib.import_module("textprompts.config"))
     assert cfg.get_metadata() == cfg.MetadataMode.STRICT
@@ -26,7 +28,7 @@ def test_env_var_overrides(monkeypatch):
     assert cfg.get_metadata() == cfg.MetadataMode.IGNORE
 
 
-def test_env_var_invalid_value(monkeypatch):
+def test_env_var_invalid_value(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("TEXTPROMPTS_METADATA_MODE", "invalid_mode")
     cfg = importlib.reload(importlib.import_module("textprompts.config"))
     assert cfg.get_metadata() == cfg.MetadataMode.IGNORE


### PR DESCRIPTION
## Summary
- add `Prompt.from_path` as the recommended loader
- update docs and README for new constructor
- adjust tests for the API change
- bump version to 0.0.4 and update changelog

## Testing
- `pre-commit run --files CHANGELOG.md README.md docs/api-reference.md pyproject.toml src/textprompts/models.py tests/test_prompt_constructor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688511540ac8832ab713e78307c022fe