### PR TITLE
Update docs and examples to use Prompt.prompt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,10 +101,14 @@ Tests are located in `tests/` and follow pytest conventions.
 TextPrompts is fully typed. All public APIs must include type hints:
 
 ```python
-from typing import Optional
 from pathlib import Path
 
-def load_prompt(path: str | Path, *, skip_meta: bool = False) -> Prompt:
+from textprompts import MetadataMode, Prompt
+
+
+def load_prompt(
+    path: str | Path, *, meta: MetadataMode | str | None = None
+) -> Prompt:
     """Load a single prompt file."""
     ...
 ```

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -23,7 +23,7 @@ from textprompts import load_prompt
 
 prompt = load_prompt("prompts/greeting.txt")
 print(prompt.meta.title)
-print(prompt.body)
+print(prompt.prompt)
 ```
 
 ### `load_prompts(*paths, recursive=False, glob="*.txt", meta=None, max_files=1000)`
@@ -68,14 +68,16 @@ Save a prompt to a file.
 
 **Example:**
 ```python
-from textprompts import save_prompt, Prompt, PromptMeta
+from pathlib import Path
+
+from textprompts import Prompt, PromptMeta, save_prompt
 
 # Save a simple prompt with metadata template
 save_prompt("my_prompt.txt", "You are a helpful assistant.")
 
 # Save a Prompt object with full metadata
 meta = PromptMeta(title="Assistant", version="1.0.0", description="A helpful AI")
-prompt = Prompt(path=Path("my_prompt.txt"), meta=meta, body="You are a helpful assistant.")
+prompt = Prompt(path=Path("my_prompt.txt"), meta=meta, prompt="You are a helpful assistant.")
 save_prompt("my_prompt.txt", prompt)
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -156,8 +156,9 @@ latest_prompt = get_latest_prompt("Customer Support")
 ### Prompt Registry
 
 ```python
-from textprompts import load_prompts
 from typing import Dict
+
+from textprompts import Prompt, load_prompts
 
 class PromptRegistry:
     def __init__(self, directory: str):
@@ -341,6 +342,6 @@ Hello {name}!"""
         assert prompts[0].meta.title == "Test Prompt"
         
         # Test formatting
-        result = prompts[0].body.format(name="Test")
+        result = prompts[0].prompt.format(name="Test")
         assert result == "Hello Test!"
 ```

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -70,7 +70,9 @@ Just use {variables} as needed.
 
 To load prompts without metadata:
 ```python
-prompt = load_prompt("simple.txt", skip_meta=True)
+from textprompts import load_prompt
+
+prompt = load_prompt("simple.txt", meta="ignore")
 ```
 
 ## Format Rules

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -37,7 +37,7 @@ prompt = load_prompt("hello.txt")
 print(prompt.meta.title)  # "Hello World"
 
 # Use the prompt
-message = prompt.body.format(name="Alice")
+message = prompt.prompt.format(name="Alice")
 print(message)  # "Hello Alice! Welcome to TextPrompts."
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,10 +36,10 @@ Best regards,
 
 **Python code**:
 ```python
-from textprompts import load_prompt
+from textprompts import load_prompt, set_metadata
 
-# Optionally, you can look for TOML metadata in the header of the file
-textprompts.set_metadata("allow") # optional!
+# Optionally, configure metadata parsing
+set_metadata("allow")  # optional!
 
 # Or set via environment variable before import
 # export TEXTPROMPTS_METADATA_MODE=allow

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -18,7 +18,7 @@ system_prompt = load_prompt("prompts/customer_agent.txt")
 # Create agent
 agent = Agent(
     'openai:gpt-4',
-    system_prompt=system_prompt.body.format(
+    system_prompt=system_prompt.prompt.format(
         company_name="ACME Corp",
         support_level="premium"
     )
@@ -47,7 +47,7 @@ agent_prompt = load_prompt("prompts/contextual_agent.txt")
 agent = Agent(
     'openai:gpt-4',
     deps_type=CustomerContext,
-    system_prompt=lambda ctx: agent_prompt.body.format(
+    system_prompt=lambda ctx: agent_prompt.prompt.format(
         customer_tier=ctx.tier,
         region=ctx.region,
         policies=get_regional_policies(ctx.region)
@@ -81,14 +81,14 @@ response = openai.chat.completions.create(
     messages=[
         {
             "role": "system",
-            "content": system_prompt.body.format(
+            "content": system_prompt.prompt.format(
                 domain="technical support",
                 tone="helpful and detailed"
             )
         },
         {
             "role": "user",
-            "content": user_prompt_template.body.format(
+            "content": user_prompt_template.prompt.format(
                 query="How do I reset my password?",
                 context="mobile app"
             )
@@ -111,7 +111,7 @@ tools = [
         "type": "function",
         "function": {
             "name": "get_weather",
-            "description": function_prompt.body.format(
+            "description": function_prompt.prompt.format(
                 function_name="get_weather",
                 purpose="Get current weather for a location"
             ),
@@ -146,7 +146,7 @@ template_prompt = load_prompt("prompts/analysis_template.txt")
 
 # Create LangChain prompt
 prompt = PromptTemplate(
-    template=str(template_prompt.body),
+    template=str(template_prompt.prompt),
     input_variables=["document", "question", "context"]
 )
 
@@ -174,8 +174,8 @@ user_prompt = load_prompt("prompts/chat_user.txt")
 
 # Create chat template
 chat_prompt = ChatPromptTemplate.from_messages([
-    SystemMessage(content=str(system_prompt.body)),
-    HumanMessage(content=str(user_prompt.body))
+    SystemMessage(content=str(system_prompt.prompt)),
+    HumanMessage(content=str(user_prompt.prompt))
 ])
 
 # Format and use
@@ -203,14 +203,14 @@ client = anthropic.Anthropic()
 response = client.messages.create(
     model="claude-3-sonnet-20240229",
     max_tokens=1000,
-    system=system_prompt.body.format(
+    system=system_prompt.prompt.format(
         expertise="software engineering",
         communication_style="technical but accessible"
     ),
     messages=[
         {
             "role": "user",
-            "content": user_prompt.body.format(
+            "content": user_prompt.prompt.format(
                 task="code review",
                 code_snippet="...",
                 focus_areas="performance, security, maintainability"
@@ -235,7 +235,7 @@ prompt_template = load_prompt("prompts/text_generation.txt")
 generator = pipeline("text-generation", model="gpt2")
 
 # Generate text
-prompt = prompt_template.body.format(
+prompt = prompt_template.prompt.format(
     topic="artificial intelligence",
     style="informative",
     length="medium"
@@ -256,7 +256,7 @@ chat_template = load_prompt("prompts/chat_template.txt")
 tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-medium")
 
 # Apply chat template
-conversation = chat_template.body.format(
+conversation = chat_template.prompt.format(
     user_message="Hello, how are you?",
     context="friendly conversation",
     personality="helpful and engaging"
@@ -283,7 +283,7 @@ response = ollama.chat(
     messages=[
         {
             'role': 'system',
-            'content': system_prompt.body.format(
+            'content': system_prompt.prompt.format(
                 domain="creative writing",
                 tone="imaginative and engaging"
             )
@@ -313,7 +313,7 @@ index = VectorStoreIndex.from_documents(documents)
 
 # Create query engine with custom prompt
 query_engine = index.as_query_engine(
-    text_qa_template=query_template.body.format(
+    text_qa_template=query_template.prompt.format(
         instruction="Answer based on the context provided",
         format="bullet points",
         tone="concise and informative"
@@ -356,7 +356,7 @@ if selected_prompt:
     
     # Extract variables
     import re
-    variables = re.findall(r'\{([^}]+)\}', prompt.body)
+    variables = re.findall(r'\{([^}]+)\}', prompt.prompt)
     
     # Input fields for variables
     st.subheader("Variables")
@@ -367,7 +367,7 @@ if selected_prompt:
     # Generate output
     if st.button("Generate"):
         try:
-            result = prompt.body.format(**values)
+            result = prompt.prompt.format(**values)
             st.subheader("Result")
             st.text_area("Generated prompt:", result, height=200)
         except ValueError as e:
@@ -409,7 +409,7 @@ async def format_prompt(request: FormatRequest):
     
     prompt = prompts[request.prompt_name]
     try:
-        result = prompt.body.format(**request.variables)
+        result = prompt.prompt.format(**request.variables)
         return {"result": result}
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
@@ -486,7 +486,7 @@ def validate_prompt_collection(directory: str):
             print(f"WARNING: {prompt.path} missing title")
         
         # Check for common issues
-        if "{" in prompt.body and "}" in prompt.body:
-            variables = re.findall(r'\{([^}]+)\}', prompt.body)
+        if "{" in prompt.prompt and "}" in prompt.prompt:
+            variables = re.findall(r'\{([^}]+)\}', prompt.prompt)
             print(f"INFO: {prompt.path} uses variables: {variables}")
 ```

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -123,7 +123,7 @@ def demonstrate_single_prompt_loading(prompt_dir):
     print(f"Description: {greeting.meta.description}")
 
     # Use the prompt
-    message = greeting.body.format(
+    message = greeting.prompt.format(
         customer_name="Alice Johnson",
         company_name="Tech Solutions Inc",
         service_type="cloud hosting",
@@ -156,7 +156,7 @@ def demonstrate_multiple_prompt_loading(prompt_dir):
     # Use support response template
     if "Support Response Template" in prompt_lookup:
         support = prompt_lookup["Support Response Template"]
-        response = support.body.format(
+        response = support.prompt.format(
             customer_name="Bob Smith",
             company_name="Tech Solutions Inc",
             issue_type="billing inquiry",
@@ -247,7 +247,7 @@ def demonstrate_no_metadata_loading(prompt_dir):
         print(f"   Version: {simple.meta.version}")
 
         # Use the prompt
-        result = simple.body.format(purpose="quick testing", variables="placeholder")
+        result = simple.prompt.format(purpose="quick testing", variables="placeholder")
         print(f"   Result: {result}")
 
     except Exception as e:

--- a/examples/metadata_modes_demo.py
+++ b/examples/metadata_modes_demo.py
@@ -82,7 +82,7 @@ def demonstrate_ignore_mode(test_dir):
             prompt = textprompts.load_prompt(file_path)
             print(f"✅ {filename}:")
             print(f"   Title: {prompt.meta.title} (from filename)")
-            print(f"   Content preview: {str(prompt.body)[:60]}...")
+            print(f"   Content preview: {str(prompt.prompt)[:60]}...")
             print()
         except Exception as e:
             print(f"❌ {filename}: {type(e).__name__}: {e}")

--- a/examples/pydantic_ai_example.py
+++ b/examples/pydantic_ai_example.py
@@ -54,7 +54,7 @@ def example_1_direct_formatting():
     customer = CustomerInfo(name="Alice", company="ACME Corp", tier="Premium")
 
     # Format the system prompt directly
-    formatted_prompt = system_prompt.body.format(
+    formatted_prompt = system_prompt.prompt.format(
         company=customer.company,
         customer_name=customer.name,
         tier=customer.tier,
@@ -99,7 +99,7 @@ def example_2_single_decorator():
     # Use single decorator to define the complete system prompt
     @agent.system_prompt
     def complete_system_prompt(ctx) -> str:
-        return system_prompt.body.format(
+        return system_prompt.prompt.format(
             company=ctx.deps.company,
             customer_name=ctx.deps.name,
             tier=ctx.deps.tier,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "textprompts"
-version = "0.0.4"
+version = "1.0"
 description = "Minimal text-based prompt-loader with TOML front-matter"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- update documentation snippets to use the stable `Prompt.prompt` API and correct metadata configuration guidance
- refresh bundled example scripts so they avoid the deprecated `Prompt.body` property and include the right imports
- bump the published project version to 1.0

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68d93b896334832aa4de6b0d65e8dbe5