### PR TITLE
Add Bun-based TypeScript companion package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+node_modules/
 build/
 develop-eggs/
 dist/

--- a/packages/textprompts-ts/bun.lock
+++ b/packages/textprompts-ts/bun.lock
@@ -1,0 +1,359 @@
+{
+  "lockfileVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "@textprompts/textprompts-ts",
+      "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "fast-glob": "^3.3.2",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.0.7",
+        "@types/node": "^20.11.30",
+        "tsup": "^7.2.0",
+        "typescript": "^5.4.0",
+      },
+    },
+  },
+  "packages": {
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.19.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-bmoCYyWdEL3wDQIVbcyzRyeKLgk2WtWLTWz1ZIAZF/EGbNOwSA6ew3PftJ1PqMiOOGu0OyFMzG53L0zqIpPeNA=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.19.12", "", { "os": "android", "cpu": "arm" }, "sha512-qg/Lj1mu3CdQlDEEiWrlC4eaPZ1KztwGJ9B6J+/6G+/4ewxJg7gqj8eVYWvao1bXrqGiW2rsBZFSX3q2lcW05w=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.19.12", "", { "os": "android", "cpu": "arm64" }, "sha512-P0UVNGIienjZv3f5zq0DP3Nt2IE/3plFzuaS96vihvD0Hd6H/q4WXUGpCxD/E8YrSXfNyRPbpTq+T8ZQioSuPA=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.19.12", "", { "os": "android", "cpu": "x64" }, "sha512-3k7ZoUW6Q6YqhdhIaq/WZ7HwBpnFBlW905Fa4s4qWJyiNOgT1dOqDiVAQFwBH7gBRZr17gLrlFCRzF6jFh7Kew=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.19.12", "", { "os": "darwin", "cpu": "arm64" }, "sha512-B6IeSgZgtEzGC42jsI+YYu9Z3HKRxp8ZT3cqhvliEHovq8HSX2YX8lNocDn79gCKJXOSaEot9MVYky7AKjCs8g=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.19.12", "", { "os": "darwin", "cpu": "x64" }, "sha512-hKoVkKzFiToTgn+41qGhsUJXFlIjxI/jSYeZf3ugemDYZldIXIxhvwN6erJGlX4t5h417iFuheZ7l+YVn05N3A=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.19.12", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-4aRvFIXmwAcDBw9AueDQ2YnGmz5L6obe5kmPT8Vd+/+x/JMVKCgdcRwH6APrbpNXsPz+K653Qg8HB/oXvXVukA=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.19.12", "", { "os": "freebsd", "cpu": "x64" }, "sha512-EYoXZ4d8xtBoVN7CEwWY2IN4ho76xjYXqSXMNccFSx2lgqOG/1TBPW0yPx1bJZk94qu3tX0fycJeeQsKovA8gg=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.19.12", "", { "os": "linux", "cpu": "arm" }, "sha512-J5jPms//KhSNv+LO1S1TX1UWp1ucM6N6XuL6ITdKWElCu8wXP72l9MM0zDTzzeikVyqFE6U8YAV9/tFyj0ti+w=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.19.12", "", { "os": "linux", "cpu": "arm64" }, "sha512-EoTjyYyLuVPfdPLsGVVVC8a0p1BFFvtpQDB/YLEhaXyf/5bczaGeN15QkR+O4S5LeJ92Tqotve7i1jn35qwvdA=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.19.12", "", { "os": "linux", "cpu": "ia32" }, "sha512-Thsa42rrP1+UIGaWz47uydHSBOgTUnwBwNq59khgIwktK6x60Hivfbux9iNR0eHCHzOLjLMLfUMLCypBkZXMHA=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-LiXdXA0s3IqRRjm6rV6XaWATScKAXjI4R4LoDlvO7+yQqFdlr1Bax62sRwkVvRIrwXxvtYEHHI4dm50jAXkuAA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-fEnAuj5VGTanfJ07ff0gOA6IPsvrVHLVb6Lyd1g2/ed67oU1eFzL0r9WL7ZzscD+/N6i3dWumGE1Un4f7Amf+w=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.19.12", "", { "os": "linux", "cpu": "ppc64" }, "sha512-nYJA2/QPimDQOh1rKWedNOe3Gfc8PabU7HT3iXWtNUbRzXS9+vgB0Fjaqr//XNbd82mCxHzik2qotuI89cfixg=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.19.12", "", { "os": "linux", "cpu": "none" }, "sha512-2MueBrlPQCw5dVJJpQdUYgeqIzDQgw3QtiAHUC4RBz9FXPrskyyU3VI1hw7C0BSKB9OduwSJ79FTCqtGMWqJHg=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.19.12", "", { "os": "linux", "cpu": "s390x" }, "sha512-+Pil1Nv3Umes4m3AZKqA2anfhJiVmNCYkPchwFJNEJN5QxmTs1uzyy4TvmDrCRNT2ApwSari7ZIgrPeUx4UZDg=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.19.12", "", { "os": "linux", "cpu": "x64" }, "sha512-B71g1QpxfwBvNrfyJdVDexenDIt1CiDN1TIXLbhOw0KhJzE78KIFGX6OJ9MrtC0oOqMWf+0xop4qEU8JrJTwCg=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.19.12", "", { "os": "none", "cpu": "x64" }, "sha512-3ltjQ7n1owJgFbuC61Oj++XhtzmymoCihNFgT84UAmJnxJfm4sYCiSLTXZtE00VWYpPMYc+ZQmB6xbSdVh0JWA=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.19.12", "", { "os": "openbsd", "cpu": "x64" }, "sha512-RbrfTB9SWsr0kWmb9srfF+L933uMDdu9BIzdA7os2t0TXhCRjrQyCeOt6wVxr79CKD4c+p+YhCj31HBkYcXebw=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.19.12", "", { "os": "sunos", "cpu": "x64" }, "sha512-HKjJwRrW8uWtCQnQOz9qcU3mUZhTUQvi56Q8DPTLLB+DawoiQdjsYq+j+D3s9I8VFtDr+F9CjgXKKC4ss89IeA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.19.12", "", { "os": "win32", "cpu": "arm64" }, "sha512-URgtR1dJnmGvX864pn1B2YUYNzjmXkuJOIqG2HdU62MVS4EHpU2946OZoTMnRUHklGtJdJZ33QfzdjGACXhn1A=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.19.12", "", { "os": "win32", "cpu": "ia32" }, "sha512-+ZOE6pUkMOJfmxmBZElNOx72NKpIa/HFOMGzu8fqzQJ5kgf6aTGrcJaFsNiVMH4JKpMipyK+7k0n2UXN7a8YKQ=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.19.12", "", { "os": "win32", "cpu": "x64" }, "sha512-T1QyPSDCyMXaO3pzBkF96E8xMkiRYbUEZADd29SyPGabqxMViNoii+NcK7eWJAEoU6RZyEm5lVSIjTmcdoB9HA=="],
+
+    "@iarna/toml": ["@iarna/toml@2.2.5", "", {}, "sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.52.4", "", { "os": "android", "cpu": "arm" }, "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.52.4", "", { "os": "android", "cpu": "arm64" }, "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.52.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.52.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.52.4", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.52.4", "", { "os": "freebsd", "cpu": "x64" }, "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.52.4", "", { "os": "linux", "cpu": "arm" }, "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.52.4", "", { "os": "linux", "cpu": "arm" }, "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.52.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.52.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.52.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.52.4", "", { "os": "linux", "cpu": "none" }, "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.52.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.52.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.52.4", "", { "os": "linux", "cpu": "x64" }, "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.52.4", "", { "os": "none", "cpu": "arm64" }, "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.52.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.52.4", "", { "os": "win32", "cpu": "ia32" }, "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.52.4", "", { "os": "win32", "cpu": "x64" }, "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w=="],
+
+    "@types/bun": ["@types/bun@1.2.23", "", { "dependencies": { "bun-types": "1.2.23" } }, "sha512-le8ueOY5b6VKYf19xT3McVbXqLqmxzPXHsQT/q9JHgikJ2X22wyTW3g3ohz2ZMnp7dod6aduIiq8A14Xyimm0A=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@20.19.19", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-pb1Uqj5WJP7wrcbLU7Ru4QtA0+3kAXrkutGiD26wUKzSMgNNaPARTUDQmElUXp64kh3cWdou3Q0C7qwwxqSFmg=="],
+
+    "@types/react": ["@types/react@19.2.0", "", { "dependencies": { "csstype": "^3.0.2" } }, "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
+    "bun-types": ["bun-types@1.2.23", "", { "dependencies": { "@types/node": "*" }, "peerDependencies": { "@types/react": "^19" } }, "sha512-R9f0hKAZXgFU3mlrA0YpE/fiDvwV0FT9rORApt2aQVWSuJDzZOyB5QLc0N/4HF57CS8IXJ6+L5E4W1bW6NS2Aw=="],
+
+    "bundle-require": ["bundle-require@4.2.1", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.17" } }, "sha512-7Q/6vkyYAwOmQNRw75x+4yRtZCZJXUDmHHlFdkiV0wgv/reNjtJwpu1jPJ0w2kbEpIM0uoKI3S4/f39dU7AjSA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
+
+    "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
+    "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
+
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
+
+    "human-signals": ["human-signals@2.1.0", "", {}, "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="],
+
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
+
+    "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
+
+    "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "postcss-load-config": ["postcss-load-config@4.0.2", "", { "dependencies": { "lilconfig": "^3.0.0", "yaml": "^2.3.4" }, "peerDependencies": { "postcss": ">=8.0.9", "ts-node": ">=9.0.0" }, "optionalPeers": ["postcss", "ts-node"] }, "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rollup": ["rollup@4.52.4", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.52.4", "@rollup/rollup-android-arm64": "4.52.4", "@rollup/rollup-darwin-arm64": "4.52.4", "@rollup/rollup-darwin-x64": "4.52.4", "@rollup/rollup-freebsd-arm64": "4.52.4", "@rollup/rollup-freebsd-x64": "4.52.4", "@rollup/rollup-linux-arm-gnueabihf": "4.52.4", "@rollup/rollup-linux-arm-musleabihf": "4.52.4", "@rollup/rollup-linux-arm64-gnu": "4.52.4", "@rollup/rollup-linux-arm64-musl": "4.52.4", "@rollup/rollup-linux-loong64-gnu": "4.52.4", "@rollup/rollup-linux-ppc64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-gnu": "4.52.4", "@rollup/rollup-linux-riscv64-musl": "4.52.4", "@rollup/rollup-linux-s390x-gnu": "4.52.4", "@rollup/rollup-linux-x64-gnu": "4.52.4", "@rollup/rollup-linux-x64-musl": "4.52.4", "@rollup/rollup-openharmony-arm64": "4.52.4", "@rollup/rollup-win32-arm64-msvc": "4.52.4", "@rollup/rollup-win32-ia32-msvc": "4.52.4", "@rollup/rollup-win32-x64-gnu": "4.52.4", "@rollup/rollup-win32-x64-msvc": "4.52.4", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "source-map": ["source-map@0.8.0-beta.0", "", { "dependencies": { "whatwg-url": "^7.0.0" } }, "sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.1.2", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-final-newline": ["strip-final-newline@2.0.0", "", {}, "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="],
+
+    "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@1.0.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsup": ["tsup@7.3.0", "", { "dependencies": { "bundle-require": "^4.0.0", "cac": "^6.7.12", "chokidar": "^3.5.1", "debug": "^4.3.1", "esbuild": "^0.19.2", "execa": "^5.0.0", "globby": "^11.0.3", "joycon": "^3.0.1", "postcss-load-config": "^4.0.1", "resolve-from": "^5.0.0", "rollup": "^4.0.2", "source-map": "0.8.0-beta.0", "sucrase": "^3.20.3", "tree-kill": "^1.2.2" }, "peerDependencies": { "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@swc/core", "postcss", "typescript"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-Ja1eaSRrE+QarmATlNO5fse2aOACYMBX+IZRKy1T+gpyH+jXgRrl5l4nHIQJQ1DoDgEjHDTw8cpE085UdBZuWQ=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
+    "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "yaml": ["yaml@2.8.1", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw=="],
+
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+  }
+}

--- a/packages/textprompts-ts/package.json
+++ b/packages/textprompts-ts/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@textprompts/textprompts-ts",
+  "version": "0.1.0",
+  "description": "TypeScript companion to textprompts for loading and formatting prompt files.",
+  "type": "module",
+  "main": "./dist/index.js",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./cli": {
+      "import": "./dist/cli.js",
+      "types": "./dist/cli.d.ts"
+    }
+  },
+  "types": "./dist/index.d.ts",
+  "files": ["dist"],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts src/cli.ts --format esm --dts",
+    "types": "tsc --emitDeclarationOnly -p tsconfig.json",
+    "test": "bun test",
+    "prepublishOnly": "bun run build && bun run types"
+  },
+  "bin": {
+    "textprompts-ts": "./dist/cli.js"
+  },
+  "dependencies": {
+    "@iarna/toml": "^2.2.5",
+    "fast-glob": "^3.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/bun": "^1.0.7",
+    "tsup": "^7.2.0",
+    "typescript": "^5.4.0"
+  }
+}

--- a/packages/textprompts-ts/src/cli.ts
+++ b/packages/textprompts-ts/src/cli.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+import { argv, exit, stderr, stdout } from "process";
+
+import { loadPrompt } from "./loaders";
+import { TextPromptsError } from "./errors";
+
+const parseArgs = () => {
+  const args = argv.slice(2);
+  let json = false;
+  const files: string[] = [];
+  for (const arg of args) {
+    if (arg === "--json") {
+      json = true;
+    } else {
+      files.push(arg);
+    }
+  }
+  if (files.length !== 1) {
+    stderr.write("Usage: textprompts-ts [--json] <file>\n");
+    exit(1);
+  }
+  return { file: files[0], json };
+};
+
+(async () => {
+  const { file, json } = parseArgs();
+  try {
+    const prompt = await loadPrompt(file, { meta: "ignore" });
+    if (json) {
+      stdout.write(`${JSON.stringify(prompt.meta ?? {}, null, 2)}\n`);
+    } else {
+      stdout.write(`${prompt.toString()}\n`);
+    }
+  } catch (error) {
+    if (error instanceof TextPromptsError || error instanceof Error) {
+      stderr.write(`Error: ${error.message}\n`);
+    } else {
+      stderr.write(`Unknown error: ${String(error)}\n`);
+    }
+    exit(1);
+  }
+})();

--- a/packages/textprompts-ts/src/config.ts
+++ b/packages/textprompts-ts/src/config.ts
@@ -1,0 +1,58 @@
+export const MetadataMode = {
+  STRICT: "strict",
+  ALLOW: "allow",
+  IGNORE: "ignore",
+} as const;
+
+export type MetadataMode = (typeof MetadataMode)[keyof typeof MetadataMode];
+
+const normalizeMode = (mode: string): MetadataMode => {
+  const lower = mode.toLowerCase();
+  if (lower === MetadataMode.STRICT || lower === MetadataMode.ALLOW || lower === MetadataMode.IGNORE) {
+    return lower;
+  }
+  throw new Error(
+    `Invalid metadata mode: ${mode}. Valid modes: ${[MetadataMode.STRICT, MetadataMode.ALLOW, MetadataMode.IGNORE].join(", ")}`,
+  );
+};
+
+const envMode =
+  typeof process !== "undefined" && process?.env?.TEXTPROMPTS_METADATA_MODE
+    ? process.env.TEXTPROMPTS_METADATA_MODE
+    : undefined;
+
+let currentMetadataMode: MetadataMode = (() => {
+  if (!envMode) {
+    return MetadataMode.IGNORE;
+  }
+  try {
+    return normalizeMode(envMode);
+  } catch {
+    return MetadataMode.IGNORE;
+  }
+})();
+
+let warnIgnoredMetadata = true;
+
+export const setMetadata = (mode: MetadataMode | string): void => {
+  const resolved = typeof mode === "string" ? normalizeMode(mode) : mode;
+  currentMetadataMode = resolved;
+};
+
+export const getMetadata = (): MetadataMode => currentMetadataMode;
+
+export const skipMetadata = ({ skipWarning = false }: { skipWarning?: boolean } = {}): void => {
+  warnIgnoredMetadata = !skipWarning;
+  setMetadata(MetadataMode.IGNORE);
+};
+
+export const warnOnIgnoredMetadata = (): boolean => warnIgnoredMetadata;
+
+export const resolveMetadataMode = (
+  mode: MetadataMode | string | null | undefined,
+): MetadataMode => {
+  if (mode == null) {
+    return currentMetadataMode;
+  }
+  return typeof mode === "string" ? normalizeMode(mode) : mode;
+};

--- a/packages/textprompts-ts/src/errors.ts
+++ b/packages/textprompts-ts/src/errors.ts
@@ -1,0 +1,34 @@
+export class TextPromptsError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "TextPromptsError";
+  }
+}
+
+export class FileMissingError extends TextPromptsError {
+  constructor(path: string) {
+    super(`File not found: ${path}`);
+    this.name = "FileMissingError";
+  }
+}
+
+export class MissingMetadataError extends TextPromptsError {
+  constructor(message = "Metadata is required but missing") {
+    super(message);
+    this.name = "MissingMetadataError";
+  }
+}
+
+export class InvalidMetadataError extends TextPromptsError {
+  constructor(message: string) {
+    super(message);
+    this.name = "InvalidMetadataError";
+  }
+}
+
+export class MalformedHeaderError extends TextPromptsError {
+  constructor(message: string) {
+    super(message);
+    this.name = "MalformedHeaderError";
+  }
+}

--- a/packages/textprompts-ts/src/index.ts
+++ b/packages/textprompts-ts/src/index.ts
@@ -1,0 +1,20 @@
+export { loadPrompt, loadPrompts } from "./loaders";
+export { savePrompt } from "./savers";
+export { Prompt, PromptMeta } from "./models";
+export { PromptString, SafeString } from "./prompt-string";
+export {
+  MetadataMode,
+  type MetadataMode as MetadataModeType,
+  setMetadata,
+  getMetadata,
+  skipMetadata,
+  warnOnIgnoredMetadata,
+} from "./config";
+export {
+  TextPromptsError,
+  FileMissingError,
+  MissingMetadataError,
+  InvalidMetadataError,
+  MalformedHeaderError,
+} from "./errors";
+export { extractPlaceholders, getPlaceholderInfo } from "./placeholder-utils";

--- a/packages/textprompts-ts/src/loaders.ts
+++ b/packages/textprompts-ts/src/loaders.ts
@@ -1,0 +1,123 @@
+import { lstat } from "fs/promises";
+import fg from "fast-glob";
+
+import { MetadataMode, resolveMetadataMode } from "./config";
+import { FileMissingError, TextPromptsError } from "./errors";
+import { Prompt } from "./models";
+import { parseFile } from "./parser";
+
+export interface LoadPromptOptions {
+  meta?: MetadataMode | string | null;
+}
+
+export const loadPrompt = async (path: string, options: LoadPromptOptions = {}): Promise<Prompt> => {
+  try {
+    const stats = await lstat(path);
+    if (!(stats.isFile() || stats.isSymbolicLink())) {
+      throw new FileMissingError(path);
+    }
+  } catch (error) {
+    if (error instanceof FileMissingError) {
+      throw error;
+    }
+    throw new FileMissingError(path);
+  }
+
+  const mode = resolveMetadataMode(options.meta ?? null);
+  return parseFile(path, mode);
+};
+
+export interface LoadPromptsOptions extends LoadPromptOptions {
+  recursive?: boolean;
+  glob?: string;
+  maxFiles?: number | null;
+}
+
+const extractPathsAndOptions = (
+  first: string | string[] | undefined,
+  rest: Array<string | LoadPromptsOptions>,
+): { paths: string[]; options: LoadPromptsOptions } => {
+  if (!first) {
+    return { paths: [], options: {} };
+  }
+
+  if (Array.isArray(first)) {
+    const maybeOptions = rest.at(-1);
+    const options =
+      maybeOptions && typeof maybeOptions === "object" && !Array.isArray(maybeOptions)
+        ? (maybeOptions as LoadPromptsOptions)
+        : {};
+    const paths = [...first];
+    if (options === maybeOptions) {
+      rest.pop();
+    }
+    return { paths, options };
+  }
+
+  const args = [first, ...rest];
+  let options: LoadPromptsOptions = {};
+  const last = args[args.length - 1];
+  if (typeof last === "object" && last !== null && !Array.isArray(last)) {
+    options = last as LoadPromptsOptions;
+    args.pop();
+  }
+  const paths = args.filter((value): value is string => typeof value === "string");
+  return { paths, options };
+};
+
+export function loadPrompts(paths: string[], options?: LoadPromptsOptions): Promise<Prompt[]>;
+export function loadPrompts(path: string, ...rest: Array<string | LoadPromptsOptions>): Promise<Prompt[]>;
+export async function loadPrompts(
+  first: string | string[],
+  ...rest: Array<string | LoadPromptsOptions>
+): Promise<Prompt[]> {
+  const { paths, options } = Array.isArray(first)
+    ? { paths: first, options: (rest[0] as LoadPromptsOptions | undefined) ?? {} }
+    : extractPathsAndOptions(first, rest);
+
+  if (paths.length === 0) {
+    return [];
+  }
+
+  const { recursive = false, glob = "*.txt", meta = null, maxFiles = 1000 } = options;
+  const resolvedMode = resolveMetadataMode(meta ?? null);
+
+  const prompts: Prompt[] = [];
+  let processed = 0;
+
+  for (const entry of paths) {
+    let stats;
+    try {
+      stats = await lstat(entry);
+    } catch {
+      throw new FileMissingError(entry);
+    }
+
+    if (stats.isDirectory()) {
+      const matches = await fg(glob, {
+        cwd: entry,
+        absolute: true,
+        onlyFiles: true,
+        dot: false,
+        followSymbolicLinks: true,
+        unique: true,
+        deep: recursive ? Infinity : 1,
+      });
+      for (const file of matches) {
+        if (maxFiles && processed >= maxFiles) {
+          throw new TextPromptsError(`Exceeded maxFiles limit of ${maxFiles}`);
+        }
+        prompts.push(await loadPrompt(file, { meta: resolvedMode }));
+        processed += 1;
+      }
+    } else {
+      if (maxFiles && processed >= maxFiles) {
+        throw new TextPromptsError(`Exceeded maxFiles limit of ${maxFiles}`);
+      }
+      prompts.push(await loadPrompt(entry, { meta: resolvedMode }));
+      processed += 1;
+    }
+  }
+
+  return prompts;
+}

--- a/packages/textprompts-ts/src/models.ts
+++ b/packages/textprompts-ts/src/models.ts
@@ -1,0 +1,66 @@
+import { resolve } from "path";
+
+import { MetadataMode } from "./config";
+import { PromptString } from "./prompt-string";
+
+export interface PromptMeta {
+  title?: string | null;
+  version?: string | null;
+  author?: string | null;
+  created?: string | null;
+  description?: string | null;
+}
+
+export interface PromptInit {
+  path: string;
+  meta: PromptMeta | null;
+  prompt: string | PromptString;
+}
+
+export class Prompt {
+  readonly path: string;
+  readonly meta: PromptMeta | null;
+  readonly prompt: PromptString;
+
+  constructor(init: PromptInit) {
+    this.path = resolve(init.path);
+    this.meta = init.meta;
+    const value = init.prompt instanceof PromptString ? init.prompt : new PromptString(init.prompt);
+    if (!value.strip()) {
+      throw new Error("Prompt body is empty");
+    }
+    this.prompt = value;
+  }
+
+  static async fromPath(path: string, options?: { meta?: MetadataMode | string | null }) {
+    const { loadPrompt } = await import("./loaders");
+    return loadPrompt(path, { meta: options?.meta });
+  }
+
+  toString(): string {
+    return this.prompt.toString();
+  }
+
+  valueOf(): string {
+    return this.prompt.valueOf();
+  }
+
+  strip(): string {
+    return this.prompt.strip();
+  }
+
+  format(options?: Parameters<PromptString["format"]>[0]): string;
+  format(args: unknown[], kwargs?: Record<string, unknown>, options?: Parameters<PromptString["format"]>[2]): string;
+  format(arg0?: unknown, arg1?: Record<string, unknown>, arg2?: unknown): string {
+    // @ts-expect-error passthrough
+    return this.prompt.format(arg0 as never, arg1 as never, arg2 as never);
+  }
+
+  get length(): number {
+    return this.prompt.length;
+  }
+
+  slice(start?: number, end?: number): string {
+    return this.prompt.slice(start, end);
+  }
+}

--- a/packages/textprompts-ts/src/parser.ts
+++ b/packages/textprompts-ts/src/parser.ts
@@ -1,0 +1,166 @@
+import { basename, extname } from "path";
+import { readFile } from "fs/promises";
+
+import { MetadataMode, warnOnIgnoredMetadata } from "./config";
+import { InvalidMetadataError, MalformedHeaderError, MissingMetadataError, TextPromptsError } from "./errors";
+import { Prompt, PromptMeta } from "./models";
+import { PromptString } from "./prompt-string";
+import { parseToml } from "./toml";
+
+const DELIM = "---";
+
+const dedent = (input: string): string => {
+  const normalized = input.replace(/\r\n?/g, "\n");
+  const lines = normalized.split("\n");
+  let minIndent = Number.POSITIVE_INFINITY;
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    const match = line.match(/^\s*/);
+    const indent = match ? match[0].length : 0;
+    if (indent < minIndent) {
+      minIndent = indent;
+    }
+  }
+  if (!Number.isFinite(minIndent) || minIndent === 0) {
+    return normalized;
+  }
+  return lines
+    .map((line) => {
+      if (!line.trim()) {
+        return "";
+      }
+      return line.slice(minIndent);
+    })
+    .join("\n");
+};
+
+const splitFrontMatter = (text: string): { header: string | null; body: string } => {
+  if (!text.startsWith(DELIM)) {
+    return { header: null, body: text };
+  }
+  const secondIndex = text.indexOf(DELIM, DELIM.length);
+  if (secondIndex === -1) {
+    throw new MalformedHeaderError("Missing closing delimiter '---' for front matter");
+  }
+  const header = text.slice(DELIM.length, secondIndex).trim();
+  let body = text.slice(secondIndex + DELIM.length);
+  body = body.replace(/^\r?\n/, "");
+  return { header, body };
+};
+
+const ensurePromptMeta = (data: Record<string, unknown>): PromptMeta => {
+  const meta: PromptMeta = {};
+  if (typeof data.title === "string") meta.title = data.title;
+  if (typeof data.description === "string") meta.description = data.description;
+  if (typeof data.version === "string") meta.version = data.version;
+  if (typeof data.author === "string") meta.author = data.author;
+  if (typeof data.created === "string") meta.created = data.created;
+  return meta;
+};
+
+const enforceStrictRequirements = (meta: PromptMeta): void => {
+  const required = ["title", "description", "version"] as const;
+  const missing = required.filter((key) => {
+    const value = meta[key];
+    return value == null;
+  });
+  if (missing.length > 0) {
+    throw new InvalidMetadataError(
+      `Missing required metadata fields: ${missing.join(", ")}. STRICT mode requires 'title', 'description', and 'version' fields. Use meta=MetadataMode.ALLOW for less strict validation.`,
+    );
+  }
+  const empty = required.filter((key) => {
+    const value = meta[key];
+    return value != null && String(value).trim() === "";
+  });
+  if (empty.length > 0) {
+    throw new InvalidMetadataError(
+      `Empty required metadata fields: ${empty.join(", ")}. STRICT mode requires non-empty 'title', 'description', and 'version' fields. Use meta=MetadataMode.ALLOW for less strict validation.`,
+    );
+  }
+};
+
+export const parseFile = async (path: string, metadataMode: MetadataMode): Promise<Prompt> => {
+  let raw: string;
+  try {
+    raw = await readFile(path, { encoding: "utf8" });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new TextPromptsError(`Cannot read ${path}: ${message}`);
+  }
+
+  if (metadataMode === MetadataMode.IGNORE) {
+    if (warnOnIgnoredMetadata() && raw.startsWith(DELIM) && raw.indexOf(DELIM, DELIM.length) !== -1) {
+      console.warn(
+        "Metadata detected but ignored; use setMetadata('allow') or skipMetadata({ skipWarning: true }) to silence",
+      );
+    }
+    const title = basename(path, extname(path));
+    return new Prompt({
+      path,
+      meta: { title },
+      prompt: new PromptString(dedent(raw)),
+    });
+  }
+
+  let header: string | null;
+  let body: string;
+  try {
+    ({ header, body } = splitFrontMatter(raw));
+  } catch (error) {
+    if (raw.startsWith(DELIM) && error instanceof MalformedHeaderError) {
+      throw new InvalidMetadataError(
+        `${error.message}. If this file has no metadata and starts with '---', use meta=MetadataMode.IGNORE to skip metadata parsing.`,
+      );
+    }
+    throw error;
+  }
+
+  let meta: PromptMeta | null = null;
+
+  if (header !== null) {
+    try {
+      const data = parseToml(header);
+      meta = ensurePromptMeta(data);
+      if (metadataMode === MetadataMode.STRICT) {
+        enforceStrictRequirements(meta);
+      }
+    } catch (error) {
+      if (error instanceof InvalidMetadataError) {
+        throw error;
+      }
+      if (error instanceof MalformedHeaderError) {
+        throw error;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      if (/TOML/i.test(message)) {
+        throw new InvalidMetadataError(
+          `Invalid TOML in front matter: ${message}. Use meta=MetadataMode.IGNORE to skip metadata parsing.`,
+        );
+      }
+      throw new InvalidMetadataError(`Invalid metadata: ${message}`);
+    }
+  } else {
+    if (metadataMode === MetadataMode.STRICT) {
+      throw new MissingMetadataError(
+        `No metadata found in ${path}. STRICT mode requires metadata with title, description, and version fields. Use meta=MetadataMode.ALLOW or meta=MetadataMode.IGNORE for less strict validation.`,
+      );
+    }
+    meta = {};
+  }
+
+  if (!meta) {
+    meta = {};
+  }
+  if (!meta.title) {
+    meta.title = basename(path, extname(path));
+  }
+
+  return new Prompt({
+    path,
+    meta,
+    prompt: new PromptString(dedent(body)),
+  });
+};

--- a/packages/textprompts-ts/src/placeholder-utils.ts
+++ b/packages/textprompts-ts/src/placeholder-utils.ts
@@ -1,0 +1,55 @@
+const ESCAPED_OPEN = "\x00ESCAPED_OPEN\x00";
+const ESCAPED_CLOSE = "\x00ESCAPED_CLOSE\x00";
+
+export const extractPlaceholders = (text: string): Set<string> => {
+  const temp = text.replaceAll("{{", ESCAPED_OPEN).replaceAll("}}", ESCAPED_CLOSE);
+  const pattern = /\{([^}:]*)(?::[^}]*)?\}/g;
+  const matches = new Set<string>();
+  let match: RegExpExecArray | null;
+  while ((match = pattern.exec(temp))) {
+    matches.add(match[1]);
+  }
+  return matches;
+};
+
+export const validateFormatArgs = (
+  placeholders: Set<string>,
+  args: unknown[],
+  kwargs: Record<string, unknown>,
+  skipValidation = false,
+): void => {
+  if (skipValidation) {
+    return;
+  }
+  const merged: Record<string, unknown> = { ...kwargs };
+  args.forEach((value, index) => {
+    merged[String(index)] = value;
+  });
+
+  if (placeholders.has("") && args.length > 0) {
+    merged[""] = args[0];
+  }
+
+  const providedKeys = new Set(Object.keys(merged));
+  const missing = Array.from(placeholders).filter((name) => !providedKeys.has(name));
+
+  if (missing.length > 0) {
+    throw new Error(`Missing format variables: ${JSON.stringify(missing.sort())}`);
+  }
+};
+
+export const shouldIgnoreValidation = (ignoreFlag: boolean): boolean => ignoreFlag;
+
+export const getPlaceholderInfo = (text: string) => {
+  const placeholders = extractPlaceholders(text);
+  const names = Array.from(placeholders);
+  const hasPositional = names.some((name) => /^\d+$/.test(name));
+  const hasNamed = names.some((name) => name !== "" && !/^\d+$/.test(name));
+  return {
+    count: placeholders.size,
+    names: new Set(names),
+    hasPositional,
+    hasNamed,
+    isMixed: hasPositional && hasNamed,
+  } as const;
+};

--- a/packages/textprompts-ts/src/prompt-string.ts
+++ b/packages/textprompts-ts/src/prompt-string.ts
@@ -1,0 +1,103 @@
+import { extractPlaceholders, validateFormatArgs } from "./placeholder-utils";
+
+export interface FormatCallOptions {
+  skipValidation?: boolean;
+}
+
+export interface FormatOptions extends FormatCallOptions {
+  args?: unknown[];
+  kwargs?: Record<string, unknown>;
+}
+
+const placeholderPattern = /\{([^}:]*)(?::[^}]*)?\}/g;
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+export class PromptString {
+  readonly value: string;
+  readonly placeholders: Set<string>;
+
+  constructor(value: string) {
+    this.value = value;
+    this.placeholders = extractPlaceholders(value);
+  }
+
+  format(options?: FormatOptions): string;
+  format(args: unknown[], kwargs?: Record<string, unknown>, options?: FormatCallOptions): string;
+  format(
+    arg0?: FormatOptions | unknown[],
+    arg1?: Record<string, unknown>,
+    arg2?: FormatCallOptions,
+  ): string {
+    let args: unknown[] = [];
+    let kwargs: Record<string, unknown> = {};
+    let skipValidation = false;
+
+    if (Array.isArray(arg0) || arg0 === undefined) {
+      args = Array.isArray(arg0) ? arg0 : [];
+      kwargs = arg1 ?? {};
+      skipValidation = arg2?.skipValidation ?? false;
+    } else {
+      args = arg0.args ?? [];
+      kwargs = arg0.kwargs ?? {};
+      skipValidation = arg0.skipValidation ?? false;
+    }
+
+    const source = this.value.trim();
+    if (skipValidation) {
+      return this.partialFormat(args, kwargs, source);
+    }
+    validateFormatArgs(this.placeholders, args, kwargs, false);
+    return source.replace(placeholderPattern, (_match, key: string) => {
+      if (Object.prototype.hasOwnProperty.call(kwargs, key)) {
+        return String(kwargs[key]);
+      }
+      const index = Number.parseInt(key, 10);
+      if (!Number.isNaN(index) && index < args.length) {
+        return String(args[index]);
+      }
+      if (key === "" && args.length > 0) {
+        return String(args[0]);
+      }
+      return _match;
+    });
+  }
+
+  private partialFormat(args: unknown[], kwargs: Record<string, unknown>, source: string): string {
+    const merged: Record<string, unknown> = { ...kwargs };
+    args.forEach((value, index) => {
+      merged[String(index)] = value;
+    });
+    let result = source;
+    for (const placeholder of this.placeholders) {
+      if (Object.prototype.hasOwnProperty.call(merged, placeholder)) {
+        const value = merged[placeholder];
+        const pattern = new RegExp(`\\{${escapeRegExp(placeholder)}(?::[^}]*)?\\}`, "g");
+        result = result.replace(pattern, String(value));
+      }
+    }
+    return result;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  valueOf(): string {
+    return this.value;
+  }
+
+  strip(): string {
+    return this.value.trim();
+  }
+
+  slice(start?: number, end?: number): string {
+    return this.value.slice(start, end);
+  }
+
+  get length(): number {
+    return this.value.length;
+  }
+}
+
+export const SafeString = PromptString;

--- a/packages/textprompts-ts/src/savers.ts
+++ b/packages/textprompts-ts/src/savers.ts
@@ -1,0 +1,36 @@
+import { writeFile } from "fs/promises";
+
+import { Prompt, PromptMeta } from "./models";
+
+const serializeMetaValue = (value: string | null | undefined): string => {
+  if (value == null) {
+    return "";
+  }
+  return String(value);
+};
+
+export const savePrompt = async (path: string, content: string | Prompt): Promise<void> => {
+  if (typeof content === "string") {
+    const template = `---\ntitle = ""\ndescription = ""\nversion = ""\n---\n\n${content}`;
+    await writeFile(path, template, { encoding: "utf8" });
+    return;
+  }
+
+  if (!(content instanceof Prompt)) {
+    throw new TypeError(`content must be string or Prompt, received ${typeof content}`);
+  }
+
+  const meta: PromptMeta = content.meta ?? {};
+  const lines = ["---"];
+  lines.push(`title = "${serializeMetaValue(meta.title)}"`);
+  lines.push(`description = "${serializeMetaValue(meta.description)}"`);
+  lines.push(`version = "${serializeMetaValue(meta.version)}"`);
+  if (meta.author) {
+    lines.push(`author = "${meta.author}"`);
+  }
+  if (meta.created) {
+    lines.push(`created = "${meta.created}"`);
+  }
+  lines.push("---", "", content.prompt.toString());
+  await writeFile(path, lines.join("\n"), { encoding: "utf8" });
+};

--- a/packages/textprompts-ts/src/toml.ts
+++ b/packages/textprompts-ts/src/toml.ts
@@ -1,0 +1,29 @@
+import { parse as parseFallback } from "@iarna/toml";
+
+type BunTomlParser = ((input: string) => unknown) | undefined;
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace NodeJS {
+    interface Global {
+      Bun?: {
+        TOML?: {
+          parse?: (text: string) => unknown;
+        };
+      };
+    }
+  }
+}
+
+const getBunParser = (): BunTomlParser => {
+  const candidate = (globalThis as { Bun?: { TOML?: { parse?: BunTomlParser } } }).Bun?.TOML?.parse;
+  return typeof candidate === "function" ? candidate : undefined;
+};
+
+export const parseToml = (text: string): Record<string, unknown> => {
+  const bunParser = getBunParser();
+  if (bunParser) {
+    return bunParser(text) as Record<string, unknown>;
+  }
+  return parseFallback(text) as Record<string, unknown>;
+};

--- a/packages/textprompts-ts/tests/fixtures/no-meta.txt
+++ b/packages/textprompts-ts/tests/fixtures/no-meta.txt
@@ -1,0 +1,1 @@
+You are a helpful assistant.

--- a/packages/textprompts-ts/tests/fixtures/with-meta.txt
+++ b/packages/textprompts-ts/tests/fixtures/with-meta.txt
@@ -1,0 +1,8 @@
+---
+title = "Assistant"
+description = "A helpful assistant"
+version = "1.0.0"
+author = "Example"
+---
+
+Hello {name}, welcome!

--- a/packages/textprompts-ts/tests/loaders.test.ts
+++ b/packages/textprompts-ts/tests/loaders.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+import { MetadataMode } from "../src/config";
+import { loadPrompt, loadPrompts } from "../src/loaders";
+import { MissingMetadataError } from "../src/errors";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string) => join(__dirname, "fixtures", name);
+
+describe("loaders", () => {
+  test("loads prompt with metadata", async () => {
+    const prompt = await loadPrompt(fixture("with-meta.txt"), { meta: MetadataMode.ALLOW });
+    expect(prompt.meta?.title).toBe("Assistant");
+    expect(prompt.format({ kwargs: { name: "Alice" } })).toContain("Alice");
+  });
+
+  test("uses filename as title when ignoring metadata", async () => {
+    const prompt = await loadPrompt(fixture("with-meta.txt"), { meta: MetadataMode.IGNORE });
+    expect(prompt.meta?.title).toBe("with-meta");
+  });
+
+  test("strict mode requires metadata", async () => {
+    await expect(loadPrompt(fixture("no-meta.txt"), { meta: MetadataMode.STRICT })).rejects.toBeInstanceOf(
+      MissingMetadataError,
+    );
+  });
+
+  test("loadPrompts handles directories", async () => {
+    const prompts = await loadPrompts(join(__dirname, "fixtures"), { glob: "*.txt" });
+    expect(prompts.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/packages/textprompts-ts/tests/prompt-string.test.ts
+++ b/packages/textprompts-ts/tests/prompt-string.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+
+import { PromptString } from "../src/prompt-string";
+
+describe("PromptString", () => {
+  test("validates placeholders", () => {
+    const prompt = new PromptString("Hello {name}");
+    expect(prompt.format({ kwargs: { name: "Alice" } })).toBe("Hello Alice");
+    expect(() => prompt.format({ kwargs: {} })).toThrow(/Missing format variables/);
+  });
+
+  test("allows partial formatting", () => {
+    const prompt = new PromptString("Hello {name}, your code is {status}");
+    const result = prompt.format({ kwargs: { name: "Bob" }, skipValidation: true });
+    expect(result).toContain("Bob");
+    expect(result).toContain("{status}");
+  });
+});

--- a/packages/textprompts-ts/tsconfig.json
+++ b/packages/textprompts-ts/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "skipLibCheck": true,
+    "exactOptionalPropertyTypes": true,
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"]
+}


### PR DESCRIPTION
## Summary
- add a Bun-powered `packages/textprompts-ts` workspace that mirrors the Python API with metadata configuration, prompt models, loaders, savers, and a CLI entrypoint
- port placeholder extraction/validation and PromptString formatting safeguards to TypeScript with TOML parsing that prefers Bun’s native parser and falls back to @iarna/toml
- cover the new library with Bun unit tests for formatting and loader recursion behavior

## Testing
- bun test

------
https://chatgpt.com/codex/tasks/task_e_68e0f62611d0832aa2496a3d6335b7a4