### PR TITLE
Add Julia port of textprompts library

### DIFF
--- a/TextPrompts.jl/Project.toml
+++ b/TextPrompts.jl/Project.toml
@@ -1,0 +1,11 @@
+name = "TextPrompts"
+uuid = "5c8f1a01-6c01-4c1d-8c51-6c7e98e1b5b3"
+authors = ["TextPrompts Contributors"]
+version = "0.1.0"
+
+[deps]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
+JSON3 = "0f8b85d8-7281-11e9-16c1-2b3c7c7f5e85"
+Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"

--- a/TextPrompts.jl/src/TextPrompts.jl
+++ b/TextPrompts.jl/src/TextPrompts.jl
@@ -1,0 +1,42 @@
+module TextPrompts
+
+export MetadataMode,
+       set_metadata,
+       get_metadata,
+       skip_metadata,
+       warn_on_ignored_metadata,
+       PromptMeta,
+       Prompt,
+       PromptString,
+       format,
+       TextPromptsError,
+       TextPromptsException,
+       FileMissingError,
+       MissingMetadataError,
+       InvalidMetadataError,
+       MalformedHeaderError,
+       load_prompt,
+       load_prompts,
+       save_prompt,
+       with_metadata_mode,
+       main
+
+include("config.jl")
+include("errors.jl")
+include("placeholder_utils.jl")
+include("prompt_string.jl")
+include("models.jl")
+include("parser.jl")
+include("loaders.jl")
+include("savers.jl")
+include("cli.jl")
+
+using .Config: MetadataMode, set_metadata, get_metadata, skip_metadata, warn_on_ignored_metadata, with_metadata_mode
+using .Errors: TextPromptsException, TextPromptsError, FileMissingError, MissingMetadataError, InvalidMetadataError, MalformedHeaderError
+using .Models: PromptMeta, Prompt
+using .PromptStrings: PromptString, format
+using .Loaders: load_prompt, load_prompts
+using .Savers: save_prompt
+using .CLI: main
+
+end

--- a/TextPrompts.jl/src/cli.jl
+++ b/TextPrompts.jl/src/cli.jl
@@ -1,0 +1,58 @@
+module CLI
+
+export main
+
+using JSON3
+using ..Config: MetadataMode
+using ..Errors: TextPromptsError, TextPromptsException
+using ..Loaders: load_prompts
+using ..Models: asdict
+
+function _usage()
+    return "Usage: textprompts <file-or-directory> [--json]"
+end
+
+function main(args=Base.ARGS)
+    json_mode = false
+    targets = String[]
+    for arg in args
+        if arg == "--json"
+            json_mode = true
+        else
+            push!(targets, arg)
+        end
+    end
+    if isempty(targets)
+        println(_usage())
+        return 0
+    end
+    try
+        prompts = load_prompts(targets...; meta=MetadataMode.IGNORE)
+        if json_mode
+            data = [Dict(
+                "path" => prompt.path,
+                "meta" => asdict(prompt.meta),
+                "prompt" => String(prompt.prompt),
+            ) for prompt in prompts]
+            println(JSON3.write(data))
+        else
+            for (idx, prompt) in enumerate(prompts)
+                idx > 1 && println()
+                println(String(prompt.prompt))
+            end
+        end
+        return 0
+    catch err
+        if err isa TextPromptsException
+            println(stderr, err)
+            return 1
+        elseif err isa TextPromptsError
+            println(stderr, err)
+            return 1
+        else
+            rethrow()
+        end
+    end
+end
+
+end

--- a/TextPrompts.jl/src/config.jl
+++ b/TextPrompts.jl/src/config.jl
@@ -1,0 +1,76 @@
+module Config
+
+export MetadataMode, set_metadata, get_metadata, skip_metadata, warn_on_ignored_metadata,
+       resolve_metadata_mode, with_metadata_mode
+
+@enum MetadataMode begin
+    STRICT
+    ALLOW
+    IGNORE
+end
+
+const ENV_VAR = "TEXTPROMPTS_METADATA_MODE"
+const _metadata_mode = Ref(MetadataMode.IGNORE)
+const _warn_on_ignored = Ref(true)
+
+function __init__()
+    if haskey(ENV, ENV_VAR)
+        try
+            set_metadata(ENV[ENV_VAR])
+        catch err
+            @warn "Ignoring invalid TEXTPROMPTS_METADATA_MODE" value=ENV[ENV_VAR] err
+        end
+    end
+end
+
+_parse_metadata_symbol(mode::AbstractString) = Symbol(lowercase(strip(mode)))
+
+function _mode_from_string(mode::AbstractString)
+    sym = _parse_metadata_symbol(mode)
+    sym === :strict && return MetadataMode.STRICT
+    sym === :allow && return MetadataMode.ALLOW
+    sym === :ignore && return MetadataMode.IGNORE
+    throw(ArgumentError("Invalid metadata mode: $(mode). Valid modes: strict, allow, ignore"))
+end
+
+set_metadata(mode::MetadataMode) = (_metadata_mode[] = mode; nothing)
+
+function set_metadata(mode::AbstractString)
+    set_metadata(_mode_from_string(mode))
+end
+
+function get_metadata()::MetadataMode
+    return _metadata_mode[]
+end
+
+function skip_metadata(; skip_warning::Bool=false)
+    _warn_on_ignored[] = !skip_warning
+    set_metadata(MetadataMode.IGNORE)
+    return nothing
+end
+
+warn_on_ignored_metadata() = _warn_on_ignored[]
+
+function resolve_metadata_mode(meta)
+    if meta === nothing
+        return get_metadata()
+    elseif meta isa MetadataMode
+        return meta
+    elseif meta isa AbstractString
+        return _mode_from_string(meta)
+    else
+        throw(ArgumentError("Invalid metadata mode type: $(typeof(meta))"))
+    end
+end
+
+function with_metadata_mode(f::Function, mode)
+    current = get_metadata()
+    set_metadata(mode)
+    try
+        return f()
+    finally
+        set_metadata(current)
+    end
+end
+
+end

--- a/TextPrompts.jl/src/errors.jl
+++ b/TextPrompts.jl/src/errors.jl
@@ -1,0 +1,38 @@
+module Errors
+
+export TextPromptsException, TextPromptsError, FileMissingError, MissingMetadataError,
+       InvalidMetadataError, MalformedHeaderError
+
+abstract type TextPromptsException <: Exception end
+
+struct TextPromptsError <: TextPromptsException
+    msg::String
+end
+
+Base.showerror(io::IO, err::TextPromptsError) = print(io, err.msg)
+
+struct FileMissingError <: TextPromptsException
+    path::String
+end
+
+Base.showerror(io::IO, err::FileMissingError) = print(io, "File not found: ", err.path)
+
+struct MissingMetadataError <: TextPromptsException
+    msg::String
+end
+
+Base.showerror(io::IO, err::MissingMetadataError) = print(io, err.msg)
+
+struct InvalidMetadataError <: TextPromptsException
+    msg::String
+end
+
+Base.showerror(io::IO, err::InvalidMetadataError) = print(io, err.msg)
+
+struct MalformedHeaderError <: TextPromptsException
+    msg::String
+end
+
+Base.showerror(io::IO, err::MalformedHeaderError) = print(io, err.msg)
+
+end

--- a/TextPrompts.jl/src/loaders.jl
+++ b/TextPrompts.jl/src/loaders.jl
@@ -1,0 +1,67 @@
+module Loaders
+
+export load_prompt, load_prompts
+
+using Glob: fnmatch
+using ..Config: MetadataMode, resolve_metadata_mode
+using ..Errors: FileMissingError, TextPromptsError
+using ..Models: Prompt
+using ..Parser: parse_file
+
+function load_prompt(path; meta=nothing)
+    filepath = String(path)
+    if !isfile(filepath)
+        throw(FileMissingError(filepath))
+    end
+    mode = resolve_metadata_mode(meta)
+    return parse_file(filepath; metadata_mode=mode)
+end
+
+function _iter_directory(dir::AbstractString, pattern::AbstractString, recursive::Bool)
+    files = String[]
+    if recursive
+        for (root, _, filenames) in walkdir(dir)
+            for file in filenames
+                fnmatch(pattern, file) || continue
+                push!(files, joinpath(root, file))
+            end
+        end
+    else
+        for file in readdir(dir)
+            full = joinpath(dir, file)
+            if isfile(full) && fnmatch(pattern, file)
+                push!(files, full)
+            end
+        end
+    end
+    sort!(files)
+    return files
+end
+
+function load_prompts(paths...; recursive::Bool=false, glob::AbstractString="*.txt", meta=nothing, max_files::Union{Int,Nothing}=1000)
+    collected = Prompt[]
+    count = 0
+    limit = max_files
+    for path in paths
+        filepath = String(path)
+        if isdir(filepath)
+            files = _iter_directory(filepath, glob, recursive)
+            for file in files
+                if limit !== nothing && count >= limit
+                    throw(TextPromptsError("Exceeded max_files limit of $(limit)"))
+                end
+                push!(collected, load_prompt(file; meta=meta))
+                count += 1
+            end
+        else
+            if limit !== nothing && count >= limit
+                throw(TextPromptsError("Exceeded max_files limit of $(limit)"))
+            end
+            push!(collected, load_prompt(filepath; meta=meta))
+            count += 1
+        end
+    end
+    return collected
+end
+
+end

--- a/TextPrompts.jl/src/models.jl
+++ b/TextPrompts.jl/src/models.jl
@@ -1,0 +1,146 @@
+module Models
+
+export PromptMeta, Prompt, asdict
+
+using Dates: Date
+using Logging: @warn
+using ..PromptStrings: PromptString
+import ..TextPrompts
+
+mutable struct PromptMeta
+    title::Union{Nothing,String}
+    version::Union{Nothing,String}
+    author::Union{Nothing,String}
+    created::Union{Nothing,Date,String}
+    description::Union{Nothing,String}
+    extras::Dict{String,Any}
+    function PromptMeta(; title=nothing, version=nothing, author=nothing, created=nothing, description=nothing, extras=Dict{String,Any}(), kwargs...)
+        extra_fields = Dict{String,Any}(extras)
+        for (k, v) in pairs(kwargs)
+            extra_fields[String(k)] = v
+        end
+        created_value = created
+        if created isa Date
+            created_value = created
+        elseif created === nothing
+            created_value = nothing
+        elseif created isa AbstractString
+            created_value = created
+        else
+            created_value = created
+        end
+        new(title, version, author, created_value, description, extra_fields)
+    end
+end
+
+PromptMeta(data::AbstractDict{<:Any,<:Any}) = begin
+    allowed = Set(["title", "version", "author", "created", "description"])
+    function getvalue(key)
+        if haskey(data, key)
+            return data[key]
+        end
+        sym = Symbol(key)
+        if haskey(data, sym)
+            return data[sym]
+        end
+        return nothing
+    end
+    extras = Dict{String,Any}()
+    for (k, v) in data
+        key_str = String(k)
+        if key_str ∉ allowed
+            extras[key_str] = v
+        end
+    end
+    return PromptMeta(
+        title=getvalue("title"),
+        version=getvalue("version"),
+        author=getvalue("author"),
+        created=getvalue("created"),
+        description=getvalue("description"),
+        extras=extras,
+    )
+end
+
+Base.getindex(meta::PromptMeta, key::AbstractString) = get(meta.extras, key, nothing)
+Base.setindex!(meta::PromptMeta, value, key::AbstractString) = (meta.extras[key] = value)
+
+function Base.show(io::IO, meta::PromptMeta)
+    fields = Dict(
+        "title" => meta.title,
+        "version" => meta.version,
+        "author" => meta.author,
+        "created" => meta.created,
+        "description" => meta.description,
+    )
+    merged = merge(fields, meta.extras)
+    print(io, "PromptMeta", merged)
+end
+
+mutable struct Prompt
+    path::String
+    meta::PromptMeta
+    prompt::PromptString
+    function Prompt(path::AbstractString, meta::PromptMeta, prompt::PromptString)
+        str_prompt = String(prompt)
+        if isempty(strip(str_prompt))
+            throw(ArgumentError("Prompt body is empty"))
+        end
+        new(String(path), meta, prompt)
+    end
+end
+
+function Prompt(path::AbstractString; meta::PromptMeta=PromptMeta(), prompt::Union{PromptString,AbstractString})
+    ps = prompt isa PromptString ? prompt : PromptString(prompt)
+    return Prompt(path, meta, ps)
+end
+
+Base.length(p::Prompt) = length(p.prompt)
+Base.getindex(p::Prompt, idx::Int) = p.prompt[idx]
+Base.getindex(p::Prompt, r::UnitRange{Int}) = p.prompt[r]
+Base.string(p::Prompt) = string(p.prompt)
+
+function Base.show(io::IO, p::Prompt)
+    if p.meta.title !== nothing
+        if p.meta.version !== nothing
+            print(io, "Prompt(title='", p.meta.title, "', version='", p.meta.version, "')")
+        else
+            print(io, "Prompt(title='", p.meta.title, "')")
+        end
+    else
+        print(io, "Prompt(path='", p.path, "')")
+    end
+end
+
+function format(p::Prompt, args...; kwargs...)
+    return format(p.prompt, args...; kwargs...)
+end
+
+function body(p::Prompt)
+    @warn "Prompt.body is deprecated; use prompt field instead" maxlog=1
+    return p.prompt
+end
+
+function asdict(meta::PromptMeta)
+    base = Dict{String,Any}()
+    meta.title !== nothing && (base["title"] = meta.title)
+    meta.version !== nothing && (base["version"] = meta.version)
+    meta.author !== nothing && (base["author"] = meta.author)
+    meta.created !== nothing && (base["created"] = meta.created)
+    meta.description !== nothing && (base["description"] = meta.description)
+    return merge(base, meta.extras)
+end
+
+function asdict(p::Prompt)
+    return Dict(
+        "path" => p.path,
+        "meta" => asdict(p.meta),
+        "prompt" => String(p.prompt),
+    )
+end
+
+function from_path(path; meta=nothing)
+    return TextPrompts.load_prompt(path; meta=meta)
+end
+
+end

--- a/TextPrompts.jl/src/parser.jl
+++ b/TextPrompts.jl/src/parser.jl
@@ -1,0 +1,127 @@
+module Parser
+
+export parse_file
+
+using TOML
+using Logging: @warn
+using ..Config: MetadataMode, warn_on_ignored_metadata
+using ..Errors: InvalidMetadataError, MalformedHeaderError, MissingMetadataError
+using ..Models: Prompt, PromptMeta
+using ..PromptStrings: PromptString
+using Base: basename
+
+const DELIM = "---"
+
+function _dedent(text::String)
+    lines = split(text, '\n'; keepempty=true)
+    indents = Int[]
+    for line in lines
+        if isempty(strip(line))
+            continue
+        end
+        spaces = findfirst(!=(' '), line)
+        if spaces === nothing
+            push!(indents, length(line))
+        else
+            push!(indents, spaces - 1)
+        end
+    end
+    if isempty(indents)
+        return text
+    end
+    trim = minimum(indents)
+    if trim == 0
+        return text
+    end
+    prefix = repeat(" ", trim)
+    adjusted_lines = [startswith(line, prefix) ? line[length(prefix)+1:end] : line for line in lines]
+    adjusted = join(adjusted_lines, "\n")
+    return adjusted
+end
+
+function _stem(path::AbstractString)
+    base = basename(String(path))
+    dot = findlast(=='.', base)
+    if dot === nothing
+        return base
+    end
+    return base[1:dot-1]
+end
+
+function _split_front_matter(text::String)
+    startswith(text, DELIM) || return nothing, text
+    second_range = findnext(DELIM, text, length(DELIM)+1)
+    if second_range === nothing
+        throw(MalformedHeaderError("Missing closing delimiter '---' for front matter"))
+    end
+    second_start = first(second_range)
+    header = strip(text[length(DELIM)+1:second_start-1])
+    body = lstrip(text[last(second_range)+1:end], '\n')
+    return header, body
+end
+
+function parse_file(path::AbstractString; metadata_mode::MetadataMode)
+    raw = read(String(path), String)
+    if metadata_mode == MetadataMode.IGNORE
+        if warn_on_ignored_metadata() && startswith(raw, DELIM)
+            second = findnext(DELIM, raw, length(DELIM)+1)
+            if second !== nothing
+                @warn "Metadata detected but ignored; call skip_metadata(skip_warning=true) to silence"
+            end
+        end
+        meta = PromptMeta(title=_stem(path))
+        return Prompt(path, meta, PromptString(_dedent(raw)))
+    end
+    try
+        header, body = _split_front_matter(raw)
+    catch e
+        if isa(e, MalformedHeaderError) && startswith(raw, DELIM)
+            throw(InvalidMetadataError("$(e.msg). Use meta=MetadataMode.IGNORE to skip metadata parsing."))
+        else
+            rethrow()
+        end
+    end
+    meta = nothing
+    if header !== nothing
+        try
+            data = TOML.parse(header)
+            if metadata_mode == MetadataMode.STRICT
+                required = ["title", "description", "version"]
+                missing = filter(x -> !haskey(data, x) && !haskey(data, Symbol(x)), required)
+                if !isempty(missing)
+                    throw(InvalidMetadataError("Missing required metadata fields: $(join(missing, ", "))."))
+                end
+                empties = String[]
+                for key in required
+                    value = haskey(data, key) ? data[key] : data[Symbol(key)]
+                    if value === nothing || isempty(strip(string(value)))
+                        push!(empties, key)
+                    end
+                end
+                if !isempty(empties)
+                    throw(InvalidMetadataError("Empty required metadata fields: $(join(empties, ", "))."))
+                end
+            end
+            meta = PromptMeta(data)
+        catch err
+            if err isa TOML.ParserError
+                throw(InvalidMetadataError("Invalid TOML in front matter: $(err)"))
+            elseif err isa InvalidMetadataError
+                rethrow()
+            else
+                throw(InvalidMetadataError("Invalid metadata: $(err)"))
+            end
+        end
+    else
+        if metadata_mode == MetadataMode.STRICT
+            throw(MissingMetadataError("No metadata found in $(path). STRICT mode requires title, description, and version."))
+        end
+        meta = PromptMeta()
+    end
+    if meta.title === nothing
+        meta.title = _stem(path)
+    end
+    return Prompt(path, meta, PromptString(_dedent(body)))
+end
+
+end

--- a/TextPrompts.jl/src/placeholder_utils.jl
+++ b/TextPrompts.jl/src/placeholder_utils.jl
@@ -1,0 +1,54 @@
+module PlaceholderUtils
+
+export extract_placeholders, validate_format_args, get_placeholder_info, should_ignore_validation
+
+using Base: isempty
+using Base.Iterators: enumerate
+
+function extract_placeholders(text::AbstractString)
+    replaced = replace(replace(String(text), "{{" => "\0ESCAPED_OPEN\0"), "}}" => "\0ESCAPED_CLOSE\0")
+    pattern = r"\{([^}:]*)(?::[^}]*)?\}"
+    result = Set{String}()
+    for m in eachmatch(Regex(pattern), replaced)
+        capture = m.captures[1]
+        capture === nothing && continue
+        push!(result, String(capture))
+    end
+    return result
+end
+
+function validate_format_args(placeholders::AbstractSet{<:AbstractString}, args::Tuple, kwargs::Dict{String,Any}; skip_validation::Bool=false)
+    skip_validation && return nothing
+    all_kwargs = copy(kwargs)
+    for (idx, value) in enumerate(args)
+        all_kwargs[string(idx - 1)] = value
+    end
+    if "" in placeholders && !isempty(args)
+        all_kwargs[""] = args[1]
+    end
+    provided = Set(string(k) for k in keys(all_kwargs))
+    expected = Set(String(p) for p in placeholders)
+    missing = setdiff(expected, provided)
+    if !isempty(missing)
+        throw(ArgumentError("Missing format variables: $(collect(sort(missing)))"))
+    end
+    return nothing
+end
+
+should_ignore_validation(ignore_flag::Bool) = ignore_flag
+
+function get_placeholder_info(text::AbstractString)
+    placeholders = extract_placeholders(text)
+    is_positional(name) = !isempty(name) && all(isdigit, name)
+    has_positional = any(is_positional(name) for name in placeholders)
+    has_named = any(!is_positional(name) for name in placeholders)
+    return Dict(
+        "count" => length(placeholders),
+        "names" => placeholders,
+        "has_positional" => has_positional,
+        "has_named" => has_named,
+        "is_mixed" => has_positional && has_named,
+    )
+end
+
+end

--- a/TextPrompts.jl/src/prompt_string.jl
+++ b/TextPrompts.jl/src/prompt_string.jl
@@ -1,0 +1,145 @@
+module PromptStrings
+
+export PromptString, format
+
+using ..PlaceholderUtils: extract_placeholders, validate_format_args
+using Printf: @sprintf
+using Base: iterate
+
+struct PromptString <: AbstractString
+    text::String
+    placeholders::Set{String}
+    function PromptString(text::AbstractString)
+        str = String(text)
+        new(str, extract_placeholders(str))
+    end
+end
+
+Base.length(ps::PromptString) = length(ps.text)
+Base.ncodeunits(ps::PromptString) = ncodeunits(ps.text)
+Base.codeunit(::Type{PromptString}) = UInt8
+Base.iterate(ps::PromptString) = iterate(ps.text)
+Base.iterate(ps::PromptString, state) = iterate(ps.text, state)
+Base.getindex(ps::PromptString, i::Int) = ps.text[i]
+Base.getindex(ps::PromptString, r::UnitRange{Int}) = ps.text[r]
+Base.String(ps::PromptString) = ps.text
+Base.convert(::Type{String}, ps::PromptString) = ps.text
+Base.print(io::IO, ps::PromptString) = print(io, ps.text)
+Base.show(io::IO, ps::PromptString) = print(io, ps.text)
+
+function Base.strip(ps::PromptString; kwargs...)
+    return PromptString(strip(ps.text; kwargs...))
+end
+
+function format(ps::PromptString, args...; skip_validation::Bool=false, kwargs...)
+    kwdict = Dict{String,Any}(String(k) => v for (k, v) in pairs(kwargs))
+    if skip_validation
+        return _partial_format(ps, args, kwdict)
+    end
+    validate_format_args(ps.placeholders, args, kwdict; skip_validation=false)
+    return _render(ps, args, kwdict; skip_missing=false)
+end
+
+function _partial_format(ps::PromptString, args, kwdict::Dict{String,Any})
+    merged = _merge_args(args, kwdict, ps.placeholders)
+    return _render(ps, (), merged; skip_missing=true)
+end
+
+function _merge_args(args, kwdict::Dict{String,Any}, placeholders)
+    merged = copy(kwdict)
+    for (idx, value) in enumerate(args)
+        merged[string(idx - 1)] = value
+    end
+    if "" in placeholders && !isempty(args)
+        merged[""] = args[1]
+    end
+    return merged
+end
+
+function _render(ps::PromptString, args, kwdict::Dict{String,Any}; skip_missing::Bool)
+    data = _merge_args(args, kwdict, ps.placeholders)
+    text = ps.text
+    io = IOBuffer()
+    i = firstindex(text)
+    while i <= lastindex(text)
+        ch = text[i]
+        if ch == '{'
+            next_i = nextind(text, i)
+            if next_i <= lastindex(text) && text[next_i] == '{'
+                write(io, '{')
+                i = nextind(text, next_i)
+                continue
+            end
+            placeholder, new_index = _consume_placeholder(text, next_i)
+            name, spec = _split_placeholder(placeholder)
+            key = String(name)
+            if haskey(data, key)
+                formatted = _apply_format(data[key], spec)
+                write(io, formatted)
+            elseif skip_missing
+                write(io, "{" * placeholder * "}")
+            else
+                throw(KeyError("Missing format variable '$key'"))
+            end
+            i = new_index
+        elseif ch == '}'
+            next_i = nextind(text, i)
+            if next_i <= lastindex(text) && text[next_i] == '}'
+                write(io, '}')
+                i = nextind(text, next_i)
+                continue
+            end
+            throw(ArgumentError("Single '}' encountered in format string"))
+        else
+            write(io, text[i])
+            i = nextind(text, i)
+        end
+    end
+    return String(take!(io))
+end
+
+function _consume_placeholder(text::String, idx::Int)
+    start = idx
+    i = idx
+    while i <= lastindex(text)
+        if text[i] == '}'
+            placeholder = text[start:prevind(text, i)]
+            return placeholder, nextind(text, i)
+        end
+        i = nextind(text, i)
+    end
+    throw(ArgumentError("Missing closing '}' in format string"))
+end
+
+function _split_placeholder(placeholder::AbstractString)
+    parts = split(String(placeholder), ":"; limit=2)
+    if length(parts) == 1
+        return parts[1], ""
+    else
+        return parts[1], parts[2]
+    end
+end
+
+function _apply_format(value, spec::AbstractString)
+    isempty(spec) && return string(value)
+    if spec == "s"
+        return string(value)
+    elseif spec == "d"
+        return string(Int(value))
+    elseif occursin(r"^0\d+d$", spec)
+        if (m = match(r"^0(\d+)d$", spec)) !== nothing
+            width = parse(Int, m.captures[1])
+            return lpad(string(Int(value)), width, '0')
+        end
+    elseif occursin(r"^\.\d+f$", spec)
+        if (m = match(r"^\.(\d+)f$", spec)) !== nothing
+            precision = parse(Int, m.captures[1])
+            return @sprintf("%.${precision}f", float(value))
+        end
+    else
+        return string(value)
+    end
+    return string(value)
+end
+
+end

--- a/TextPrompts.jl/src/savers.jl
+++ b/TextPrompts.jl/src/savers.jl
@@ -1,0 +1,78 @@
+module Savers
+
+export save_prompt
+
+using Dates
+using TOML
+using ..Models: Prompt, PromptMeta, asdict
+
+function _stringify_date(value)
+    if value isa Date
+        return Dates.format(value, dateformat"yyyy-mm-dd")
+    elseif value isa DateTime
+        return Dates.format(value, dateformat"yyyy-mm-ddTHH:MM:SS")
+    else
+        return value
+    end
+end
+
+function save_prompt(path, content)
+    filepath = String(path)
+    if content isa AbstractString
+        template = """---
+title = ""
+description = ""
+version = ""
+---
+
+$content"""
+        open(filepath, "w") do io
+            write(io, template)
+        end
+    elseif content isa Prompt
+        meta = content.meta
+        meta === nothing && (meta = PromptMeta())
+        data = Dict{String,Any}()
+        data["title"] = meta.title === nothing ? "" : meta.title
+        data["description"] = meta.description === nothing ? "" : meta.description
+        data["version"] = meta.version === nothing ? "" : meta.version
+        meta.author !== nothing && (data["author"] = meta.author)
+        if meta.created !== nothing
+            data["created"] = _stringify_date(meta.created)
+        end
+        for (k, v) in meta.extras
+            data[k] = v
+        end
+        io = IOBuffer()
+        TOML.print(io, data)
+        header = String(take!(io))
+        open(filepath, "w") do io2
+            write(io2, "---\n")
+            write(io2, header)
+            if !endswith(header, "\n")
+                write(io2, "\n")
+            end
+            write(io2, "---\n\n")
+            write(io2, String(content.prompt))
+        end
+    elseif content isa PromptMeta
+        # Allow saving metadata template with no prompt
+        data = asdict(content)
+        io = IOBuffer()
+        TOML.print(io, data)
+        header = String(take!(io))
+        open(filepath, "w") do io2
+            write(io2, "---\n")
+            write(io2, header)
+            if !endswith(header, "\n")
+                write(io2, "\n")
+            end
+            write(io2, "---\n")
+        end
+    else
+        throw(ArgumentError("content must be string, Prompt, or PromptMeta"))
+    end
+    return nothing
+end
+
+end

--- a/TextPrompts.jl/test/runtests.jl
+++ b/TextPrompts.jl/test/runtests.jl
@@ -1,0 +1,70 @@
+using Test
+using TextPrompts
+using Dates
+
+@testset "PromptString" begin
+    ps = PromptString("Hello {name}! Today is {0:04d}.")
+    @test "name" in ps.placeholders
+    @test "0" in ps.placeholders
+    formatted = format(ps, 7; name="Alice")
+    @test formatted == "Hello Alice! Today is 0007."
+    partial = format(ps; skip_validation=true, name="Bob")
+    @test occursin("Bob", partial)
+    @test occursin("{0:04d}", partial)
+    @test_throws ArgumentError format(ps; name="Charlie")
+end
+
+function write_prompt(dir, filename, content)
+    path = joinpath(dir, filename)
+    open(path, "w") do io
+        write(io, content)
+    end
+    return path
+end
+
+sample_prompt = """---
+title = "Sample"
+description = "Demo"
+version = "1.0"
+---
+
+You are {role}."""
+
+@testset "Parser" begin
+    mktempdir() do dir
+        path = write_prompt(dir, "prompt.txt", sample_prompt)
+        prompt = TextPrompts.Parser.parse_file(path; metadata_mode=MetadataMode.ALLOW)
+        @test prompt.meta.title == "Sample"
+        @test String(prompt.prompt) == "You are {role}."
+        @test_throws MissingMetadataError TextPrompts.Parser.parse_file(path; metadata_mode=MetadataMode.STRICT)
+        prompt_ignore = TextPrompts.Parser.parse_file(path; metadata_mode=MetadataMode.IGNORE)
+        @test prompt_ignore.meta.title == "prompt"
+        @test occursin("You are", String(prompt_ignore.prompt))
+    end
+end
+
+@testset "Loaders" begin
+    mktempdir() do dir
+        write_prompt(dir, "a.txt", sample_prompt)
+        write_prompt(dir, "b.txt", replace(sample_prompt, "Sample" => "Second"))
+        prompts = load_prompts(dir; glob="*.txt", meta=MetadataMode.ALLOW)
+        @test length(prompts) == 2
+        titles = sort([p.meta.title for p in prompts])
+        @test titles == ["Sample", "Second"]
+    end
+end
+
+@testset "Savers" begin
+    mktempdir() do dir
+        outpath = joinpath(dir, "saved.txt")
+        save_prompt(outpath, "Testing body")
+        text = read(outpath, String)
+        @test occursin("title", text)
+        prompt = load_prompt(outpath; meta=MetadataMode.ALLOW)
+        prompt.meta.title = "Saved"
+        save_prompt(outpath, prompt)
+        text2 = read(outpath, String)
+        @test occursin("Saved", text2)
+    end
+end
+


### PR DESCRIPTION
## Summary
- scaffold a Julia package that mirrors the textprompts API and exports the same surface area
- implement metadata configuration, parsing, loaders, savers, placeholder validation, and CLI behaviour in Julia
- add Julia tests covering prompt formatting, parser behaviours, filesystem loaders, and saving helpers

## Testing
- `julia --project=TextPrompts.jl -e 'using Pkg; Pkg.test()'` *(fails: julia not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1042068a0832ab7f8aa1e1fc2c37a