### PR TITLE
Remove deprecated Prompt.body alias

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -65,7 +65,7 @@ agent = Agent(
 
 @agent.system_prompt
 def contextual_prompt(ctx: RunContext[CustomerContext]) -> str:
-    return agent_prompt.body.format(
+    return agent_prompt.prompt.format(
         customer_tier=ctx.deps.tier,
         region=ctx.deps.region,
         policies=get_regional_policies(ctx.deps.region)

--- a/src/textprompts/cli.py
+++ b/src/textprompts/cli.py
@@ -21,7 +21,7 @@ def main() -> None:
         if args.json:
             print(json.dumps(prompt.meta.model_dump() if prompt.meta else {}, indent=2))
         else:
-            print(prompt.body)
+            print(prompt.prompt)
     except TextPromptsError as e:
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/src/textprompts/models.py
+++ b/src/textprompts/models.py
@@ -50,17 +50,6 @@ class Prompt(BaseModel):
     def __str__(self) -> str:
         return str(self.prompt)
 
-    @property
-    def body(self) -> PromptString:
-        import warnings
-
-        warnings.warn(
-            "Prompt.body is deprecated; use .prompt instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.prompt
-
     def __len__(self) -> int:
         return len(self.prompt)
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -162,12 +162,13 @@ def test_prompt_model_validation_edge_cases(tmp_path: Path) -> None:
     assert str(prompt) == "Just content"
 
 
-def test_body_property_deprecated(tmp_path: Path) -> None:
+def test_prompt_has_no_body_alias(tmp_path: Path) -> None:
     test_file = tmp_path / "deprecated.txt"
     test_file.write_text("Hello")
     prompt = load_prompt(test_file, meta="ignore")
-    with pytest.deprecated_call():
-        _ = prompt.body
+    assert not hasattr(prompt, "body")
+    with pytest.raises(AttributeError):
+        getattr(prompt, "body")
 
 
 def test_prompt_model_repr_with_version(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- remove the deprecated Prompt.body property and rely on Prompt.prompt
- update the CLI, tests, and documentation to reference the current attribute

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e28a9e1cc8832ab8b208bdd07ab61a