### PR TITLE
Align section parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-03-19
+
+### Changed
+- Section anchors now normalize to underscore IDs, and generic XML sections default to tag-based anchors
+
 ## [1.4.0] - 2026-03-15
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ save_prompt("my_prompt.txt", prompt_object)
 Parse mixed Markdown/XML prompt structure without going through the file loader.
 
 - `parse_sections(text)`: Returns a `ParseResult` with `sections`, `anchors`, `duplicate_anchors`, `frontmatter`, and `total_chars`
-- `generate_slug(heading)`: Creates the same auto-anchor slug used by the parser
+- `generate_slug(heading)`: Creates the same auto-anchor slug used by the parser (lowercase, non-alphanumeric runs -> `_`)
 - `inject_anchors(text)`: Inserts missing `<a id="..."></a>` lines before Markdown headings and returns `(text, result)`
 - `render_toc(result, path)`: Renders a human-readable table of contents
 
@@ -433,6 +433,8 @@ print(anchored_text)  # <a id="intro"></a>\n## Intro...
 
 print(render_toc(anchored, "prompt.txt"))
 ```
+
+Anchor IDs use a canonical underscore form. For example, `generate_slug("My Section")` returns `my_section`, `id="my-section"` normalizes to `my_section`, and generic XML sections default to the normalized tag name when no explicit `id` is present.
 
 ### `PromptString`
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -173,6 +173,11 @@ Parse prompt structure directly from text without loading a `Prompt`.
 - `frontmatter`: Detected YAML/TOML frontmatter block, if present
 - `total_chars`: UTF-8 byte count of the body after frontmatter
 
+**Anchor behavior:**
+- Anchor ids normalize to lowercase underscore form, collapsing non-alphanumeric runs to `_`
+- `generate_slug("My Section")` returns `my_section`
+- Generic XML sections use the normalized tag name as the anchor id when no explicit `id` is present
+
 **Example:**
 ```python
 from textprompts import parse_sections, render_toc

--- a/packages/textprompts-go/CHANGELOG.md
+++ b/packages/textprompts-go/CHANGELOG.md
@@ -7,6 +7,11 @@ and this package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-03-19
+
+### Changed
+- Section anchors now normalize to underscore IDs, and generic XML sections default to tag-based anchors
+
 ## [0.2.0] - 2026-03-15
 
 ### Added

--- a/packages/textprompts-go/README.md
+++ b/packages/textprompts-go/README.md
@@ -155,7 +155,15 @@ anchored, parsed := textprompts.InjectAnchors([]byte("## Intro\n\nBody."))
 fmt.Println(string(anchored))
 
 fmt.Println(textprompts.RenderTOC(parsed, "prompt.txt"))
+
+// Normalize anchor IDs (lowercase, non-alphanumeric runs → "_")
+fmt.Println(textprompts.NormalizeAnchorID("My-Section")) // "my_section"
+fmt.Println(textprompts.GenerateSlug("My Section"))      // "my_section"
 ```
+
+#### Anchor ID normalization
+
+All anchor IDs use a single canonical form: lowercase, non-alphanumeric runs collapsed to `_`, leading/trailing `_` stripped. `NormalizeAnchorID` is applied universally to XML tag names, `id=` attributes, Markdown headings, and `<a id="">` anchors.
 
 ## Development
 

--- a/packages/textprompts-go/section.go
+++ b/packages/textprompts-go/section.go
@@ -390,6 +390,7 @@ func NormalizeAnchorID(id string) string {
 	if len(out) == 0 {
 		return "section"
 	}
+
 	return string(out)
 }
 
@@ -401,6 +402,7 @@ func GenerateSlug(heading string) string {
 	slug = reHTMLTag.ReplaceAllString(slug, "")
 	// Strip markdown formatting characters
 	slug = reMDFormatting.ReplaceAllString(slug, "")
+
 	return NormalizeAnchorID(slug)
 }
 

--- a/packages/textprompts-go/section.go
+++ b/packages/textprompts-go/section.go
@@ -251,10 +251,14 @@ func ParseSections(data []byte) *ParseResult {
 				parentIdx := parentIndex(stack)
 				level := deriveXMLLevel(result, parentIdx)
 
+				explicitID := explicitAnchorFromAttrs(block.attrs)
+				if explicitID == "" {
+					explicitID = NormalizeAnchorID(block.tagName)
+				}
 				anchorID, explicit := resolveSectionAnchor(
 					heading,
 					pending,
-					explicitAnchorFromAttrs(block.attrs),
+					explicitID,
 					usedAnchorIDs,
 				)
 
@@ -364,33 +368,40 @@ func ParseSections(data []byte) *ParseResult {
 	return result
 }
 
-// GenerateSlug creates a GFM-compatible anchor slug from heading text.
-func GenerateSlug(heading string) string {
-	s := reLinkInline.ReplaceAllString(heading, "$1")
-	s = reHTMLTag.ReplaceAllString(s, "")
-	s = reMDFormatting.ReplaceAllString(s, "")
-	s = strings.ToLower(s)
-
-	var b strings.Builder
-	for _, r := range s {
-		switch {
-		case unicode.IsSpace(r):
-			b.WriteByte('-')
-		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-':
-			b.WriteRune(r)
+// NormalizeAnchorID converts any string into a canonical anchor ID:
+// lowercase, with runs of non-alphanumeric characters replaced by a
+// single underscore, and leading/trailing underscores stripped.
+func NormalizeAnchorID(id string) string {
+	var out []rune
+	lastWasUnderscore := false
+	for _, r := range strings.ToLower(id) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			out = append(out, r)
+			lastWasUnderscore = false
+		} else if !lastWasUnderscore && len(out) > 0 {
+			out = append(out, '_')
+			lastWasUnderscore = true
 		}
 	}
-
-	slug := b.String()
-	for strings.Contains(slug, "--") {
-		slug = strings.ReplaceAll(slug, "--", "-")
+	// Strip trailing underscore
+	for len(out) > 0 && out[len(out)-1] == '_' {
+		out = out[:len(out)-1]
 	}
-	slug = strings.Trim(slug, "-")
-	if slug == "" {
-		slug = defaultSectionSlug
+	if len(out) == 0 {
+		return "section"
 	}
+	return string(out)
+}
 
-	return slug
+// GenerateSlug creates a GFM-compatible anchor slug from heading text.
+func GenerateSlug(heading string) string {
+	// Strip markdown link text: [text](url) -> text
+	slug := reLinkInline.ReplaceAllString(heading, "$1")
+	// Strip HTML tags
+	slug = reHTMLTag.ReplaceAllString(slug, "")
+	// Strip markdown formatting characters
+	slug = reMDFormatting.ReplaceAllString(slug, "")
+	return NormalizeAnchorID(slug)
 }
 
 // InjectAnchors idempotently injects <a id="..."></a> anchors before markdown headings.
@@ -613,7 +624,7 @@ func parseMarkdownHeading(line string) (level int, heading, attrID string, ok bo
 	heading = strings.TrimSpace(matches[2])
 	heading = stripClosingHeadingHashes(heading)
 	if attrMatch := reAttrID.FindStringSubmatch(heading); attrMatch != nil {
-		attrID = attrMatch[1]
+		attrID = NormalizeAnchorID(attrMatch[1])
 		heading = strings.TrimSpace(reAttrID.ReplaceAllString(heading, ""))
 	}
 
@@ -738,7 +749,7 @@ func parseTagAttributes(attrText string) map[string]string {
 func explicitAnchorFromAttrs(attrs map[string]string) string {
 	for _, key := range []string{"id", "name"} {
 		if value := strings.TrimSpace(attrs[key]); value != "" {
-			return value
+			return NormalizeAnchorID(value)
 		}
 	}
 
@@ -751,7 +762,7 @@ func extractXMLCommentAnchor(line string) string {
 		return ""
 	}
 
-	return matches[1]
+	return NormalizeAnchorID(matches[1])
 }
 
 func mergePendingAnchor(existing *pendingAnchor, id string, lineNum int) *pendingAnchor {
@@ -786,7 +797,7 @@ func uniqueGeneratedAnchor(base string, used map[string]struct{}) string {
 		return base
 	}
 	for i := 2; ; i++ {
-		candidate := fmt.Sprintf("%s-%d", base, i)
+		candidate := fmt.Sprintf("%s_%d", base, i)
 		if _, exists := used[candidate]; !exists {
 			return candidate
 		}

--- a/packages/textprompts-go/section_test.go
+++ b/packages/textprompts-go/section_test.go
@@ -71,17 +71,17 @@ func TestGenerateSlug(t *testing.T) {
 		input string
 		want  string
 	}{
-		{"Hello World", "hello-world"},
-		{"GCP Projects", "gcp-projects"},
-		{"Memory Architecture Design", "memory-architecture-design"},
-		{"**Bold** and *italic*", "bold-and-italic"},
-		{"`code` blocks", "code-blocks"},
-		{"[Link Text](http://example.com)", "link-text"},
-		{"<em>Inline HTML</em>", "inline-html"},
-		{"Multiple   Spaces", "multiple-spaces"},
-		{"Special!@#$%^&*()chars", "specialchars"},
-		{"  Leading/Trailing  ", "leadingtrailing"},
-		{"123 Numbers First", "123-numbers-first"},
+		{"Hello World", "hello_world"},
+		{"GCP Projects", "gcp_projects"},
+		{"Memory Architecture Design", "memory_architecture_design"},
+		{"**Bold** and *italic*", "bold_and_italic"},
+		{"`code` blocks", "code_blocks"},
+		{"[Link Text](http://example.com)", "link_text"},
+		{"<em>Inline HTML</em>", "inline_html"},
+		{"Multiple   Spaces", "multiple_spaces"},
+		{"Special!@#$%^&*()chars", "special_chars"},
+		{"  Leading/Trailing  ", "leading_trailing"},
+		{"123 Numbers First", "123_numbers_first"},
 		{"---dashes---", "dashes"},
 		{"", "section"},
 	}
@@ -130,7 +130,7 @@ Nested content.`
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Section One",
-			anchor:    "section-one",
+			anchor:    "section_one",
 			level:     2,
 			startLine: 5,
 			endLine:   8,
@@ -141,7 +141,7 @@ Nested content.`
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Section Two",
-			anchor:    "section-two",
+			anchor:    "section_two",
 			level:     2,
 			startLine: 9,
 			endLine:   15,
@@ -189,7 +189,7 @@ Content.`
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "First Heading",
-			anchor:    "first-heading",
+			anchor:    "first_heading",
 			level:     2,
 			startLine: 5,
 			endLine:   7,
@@ -212,7 +212,7 @@ Body.`
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "My Section",
-			anchor:    "custom-id",
+			anchor:    "custom_id",
 			level:     2,
 			startLine: 1,
 			endLine:   4,
@@ -237,7 +237,7 @@ Content.
 			kind:      sectionKindXML,
 			tag:       "section",
 			heading:   "Data Flow",
-			anchor:    "data-flow",
+			anchor:    "data_flow",
 			level:     1,
 			startLine: 1,
 			endLine:   5,
@@ -248,7 +248,7 @@ Content.
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Data Flow",
-			anchor:    "data-flow-2",
+			anchor:    "data_flow_2",
 			level:     2,
 			startLine: 2,
 			endLine:   5,
@@ -285,7 +285,7 @@ Follow the instructions carefully.
 			kind:      sectionKindXML,
 			tag:       "examples",
 			heading:   "Worked Example",
-			anchor:    "worked-example",
+			anchor:    "examples",
 			level:     1,
 			startLine: 5,
 			endLine:   5,
@@ -313,7 +313,7 @@ Inner two.
 			kind:      sectionKindXML,
 			tag:       "prompt",
 			heading:   "Prompt Root",
-			anchor:    "prompt-root",
+			anchor:    "prompt_root",
 			level:     1,
 			startLine: 1,
 			endLine:   8,
@@ -325,7 +325,7 @@ Inner two.
 			kind:      sectionKindXML,
 			tag:       "section",
 			heading:   "Inner One",
-			anchor:    "inner-one",
+			anchor:    "inner_one",
 			level:     2,
 			startLine: 2,
 			endLine:   4,
@@ -337,7 +337,7 @@ Inner two.
 			kind:      sectionKindXML,
 			tag:       "section",
 			heading:   "Inner Two",
-			anchor:    "inner-two",
+			anchor:    "inner_two",
 			level:     2,
 			startLine: 5,
 			endLine:   7,
@@ -360,7 +360,7 @@ Body.`
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Heading",
-			anchor:    "custom-id",
+			anchor:    "custom_id",
 			level:     2,
 			startLine: 1,
 			endLine:   4,
@@ -391,7 +391,7 @@ func TestParseSections_IgnoresCodeFences(t *testing.T) {
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Real Heading",
-			anchor:    "real-heading",
+			anchor:    "real_heading",
 			level:     2,
 			startLine: 7,
 			endLine:   9,
@@ -412,7 +412,7 @@ func TestParseSections_AlternateAnchorSyntaxAndHeadingCleanup(t *testing.T) {
 		{
 			kind:      sectionKindMarkdown,
 			heading:   "Heading",
-			anchor:    "named-anchor",
+			anchor:    "named_anchor",
 			level:     2,
 			startLine: 1,
 			endLine:   2,
@@ -542,14 +542,14 @@ More.`
 	assertParserInvariants(t, result)
 
 	text := string(output)
-	if !strings.Contains(text, `<a id="first-section"></a>`) {
+	if !strings.Contains(text, `<a id="first_section"></a>`) {
 		t.Fatal("expected anchor injection for markdown heading without explicit id")
 	}
 	if strings.Contains(text, `<a id="instructions"></a>`) {
 		t.Fatal("should not inject anchors for XML sections")
 	}
-	if strings.Count(text, `<a id="first-section"></a>`) != 1 {
-		t.Fatal("expected exactly one injected first-section anchor")
+	if strings.Count(text, `<a id="first_section"></a>`) != 1 {
+		t.Fatal("expected exactly one injected first_section anchor")
 	}
 
 	output2, result2 := InjectAnchors(output)
@@ -601,7 +601,7 @@ func TestParseSections_AdversarialCorpus(t *testing.T) {
 ## Third
 
 ## Fourth`,
-			wantAnchors: []string{"explicit-one", "attr-two", "comment-three", "fourth"},
+			wantAnchors: []string{"explicit_one", "attr_two", "comment_three", "fourth"},
 			wantKinds:   []string{sectionKindMarkdown, sectionKindMarkdown, sectionKindMarkdown, sectionKindMarkdown},
 		},
 		{
@@ -620,7 +620,7 @@ func TestParseSections_AdversarialCorpus(t *testing.T) {
 Example.
 </examples>
 </prompt>`,
-			wantAnchors: []string{"prompt", "overview", "worked-examples"},
+			wantAnchors: []string{"prompt", "overview", "worked_examples"},
 			wantKinds:   []string{sectionKindXML, sectionKindMarkdown, sectionKindXML},
 		},
 	}

--- a/packages/textprompts-ts/CHANGELOG.md
+++ b/packages/textprompts-ts/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-03-19
+
+### Changed
+- Section anchors now normalize to underscore IDs, generic XML sections use tag-based anchors, and TypeScript adds section body loading helpers
+
 ## [0.6.0] - 2026-03-15
 
 ### Added
@@ -56,7 +61,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test suite
 - Examples for OpenAI, Anthropic, and Vercel AI SDK
 
-[Unreleased]: https://github.com/svilupp/textprompts/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/svilupp/textprompts/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/svilupp/textprompts/releases/tag/v0.7.0
 [0.6.0]: https://github.com/svilupp/textprompts/releases/tag/v0.6.0
 [0.5.0]: https://github.com/svilupp/textprompts/releases/tag/v0.5.0
 [0.4.0]: https://github.com/svilupp/textprompts/releases/tag/v0.4.0

--- a/packages/textprompts-ts/README.md
+++ b/packages/textprompts-ts/README.md
@@ -438,12 +438,16 @@ async function savePrompt(
 Parse mixed Markdown/XML prompt structure directly from a string or `Uint8Array`.
 
 - `parseSections(text)`: Returns a `ParseResult` with `sections`, `anchors`, `duplicateAnchors`, `frontmatter`, and `totalChars`
-- `generateSlug(heading)`: Creates the same auto-anchor slug used by the parser
+- `generateSlug(heading)`: Creates the same auto-anchor slug used by the parser (lowercase, non-alphanumeric runs → `_`)
+- `normalizeAnchorId(id)`: Canonical normalization — lowercase, collapse non-alphanumeric runs to `_`, strip leading/trailing `_`
 - `injectAnchors(text)`: Inserts missing `<a id="..."></a>` lines before Markdown headings
 - `renderToc(result, path)`: Renders a human-readable table of contents
+- `getSectionText(text, anchorId)`: Look up a section body by anchor ID (fuzzy: normalizes both query and stored IDs)
+- `sliceSectionContent(text, section)`: Extract the body text of a section using its content boundary fields
+- `loadSection(path, anchorId, options?)`: Load a named section from a file as a `Prompt`
 
 ```typescript
-import { injectAnchors, parseSections, renderToc } from "textprompts";
+import { injectAnchors, loadSection, parseSections, renderToc, getSectionText, sliceSectionContent, normalizeAnchorId } from "textprompts";
 
 const result = parseSections("## Intro\n\nBody.");
 console.log(result.sections[0].anchorId); // "intro"
@@ -452,7 +456,38 @@ const anchored = injectAnchors("## Intro\n\nBody.");
 console.log(anchored.text); // <a id="intro"></a>\n## Intro...
 
 console.log(renderToc(anchored.result, "prompt.txt"));
+
+// Look up a section body (tolerates "my-section", "my_section", "MY_SECTION")
+const sectionText = getSectionText(text, "intro");
+console.log(sectionText); // "Body."
+
+// Extract body content of a section (excludes heading line)
+const text = "## Intro\n\nBody.";
+const body = sliceSectionContent(text, result.sections[0]);
+console.log(body); // "Body."
+
+// Load a named XML section from a multi-section file
+// agents.txt: <system id="default">...</system>  <system id="expert">...</system>
+const expert = await loadSection("agents.txt", "expert");
+console.log(String(expert)); // "You are an expert assistant..."
+
+// normalizeAnchorId is applied universally: XML tags, id= attrs, headings
+console.log(normalizeAnchorId("My-Section")); // "my_section"
+console.log(normalizeAnchorId("USER_TEMPLATE")); // "user_template"
 ```
+
+#### Anchor ID normalization
+
+All anchor IDs use a single canonical form: lowercase, non-alphanumeric runs collapsed to `_`, leading/trailing `_` stripped.
+
+| Source | Raw | Normalized |
+|--------|-----|------------|
+| XML tag name | `<user_template>` | `user_template` |
+| XML `id=` attr | `id="my-section"` | `my_section` |
+| Markdown heading | `## My Section` | `my_section` |
+| `<a id="">` | `<a id="custom-ID">` | `custom_id` |
+
+This means `loadSection("file.txt", "my-section")`, `"my_section"`, and `"MY_SECTION"` all find the same section.
 
 ### `PromptString`
 
@@ -641,6 +676,7 @@ See the [examples/](./examples/) directory for complete, runnable examples:
 - **[basic-usage.ts](./examples/basic-usage.ts)** - Core functionality demo
 - **[fromstring-example.ts](./examples/fromstring-example.ts)** - Loading from strings for bundlers
 - **[simple-format-demo.ts](./examples/simple-format-demo.ts)** - PromptString features
+- **[sections-usage.ts](./examples/sections-usage.ts)** - XML/Markdown section parsing and extraction
 - **[openai-example.ts](./examples/openai-example.ts)** - OpenAI integration
 - **[aisdk-example.ts](./examples/aisdk-example.ts)** - Vercel AI SDK streaming chat
 
@@ -648,6 +684,7 @@ Run them with:
 ```bash
 bun examples/basic-usage.ts
 bun examples/fromstring-example.ts
+bun examples/sections-usage.ts
 bun examples/openai-example.ts
 bun examples/aisdk-example.ts
 ```

--- a/packages/textprompts-ts/docs/api.md
+++ b/packages/textprompts-ts/docs/api.md
@@ -100,6 +100,27 @@ const limited = await loadPrompts("prompts/", { maxFiles: 10 });
 
 ---
 
+### `loadSection()`
+
+Load a single section body from a prompt file.
+
+```typescript
+async function loadSection(
+  path: string,
+  anchorId: string,
+  options?: LoadPromptOptions
+): Promise<Prompt>
+```
+
+**Parameters:**
+- `path: string` - Path to the prompt file
+- `anchorId: string` - Section anchor id or XML tag name; normalized lookups accept hyphens and underscores
+- `options?: LoadPromptOptions` - Optional metadata handling configuration for the extracted section
+
+**Returns:** `Promise<Prompt>` - The extracted section as a prompt
+
+---
+
 ### `savePrompt()`
 
 Save a prompt to a file.
@@ -158,7 +179,7 @@ function parseSections(text: string | Uint8Array): ParseResult
 ```
 
 **Returns:** `ParseResult` with:
-- `sections`: Ordered section tree with `kind`, `tagName`, `heading`, `anchorId`, `level`, `startLine`, `endLine`, `charCount`, `parentIdx`, `children`, and `links`
+- `sections`: Ordered section tree with `kind`, `tagName`, `heading`, `anchorId`, `level`, `startLine`, `endLine`, `contentStartLine`, `contentStartCol`, `contentEndLine`, `contentEndCol`, `charCount`, `parentIdx`, `children`, and `links`
 - `anchors`: Canonical anchor id to first section index
 - `duplicateAnchors`: Explicit duplicate anchors preserved by the parser
 - `frontmatter`: Detected YAML/TOML frontmatter block, if present
@@ -166,6 +187,9 @@ function parseSections(text: string | Uint8Array): ParseResult
 
 **Related utilities:**
 - `generateSlug(heading: string): string`
+- `normalizeAnchorId(id: string): string`
+- `getSectionText(text: string | Uint8Array, anchorId: string): string | null`
+- `sliceSectionContent(text: string | Uint8Array, section: Section): string`
 - `injectAnchors(text: string | Uint8Array): { text: string; result: ParseResult }`
 - `renderToc(result: ParseResult, path: string): string`
 

--- a/packages/textprompts-ts/examples/README.md
+++ b/packages/textprompts-ts/examples/README.md
@@ -47,6 +47,19 @@ Focused demonstration of the PromptString feature:
 bun examples/simple-format-demo.ts
 ```
 
+### `sections-usage.ts`
+Demonstrates section parsing, extraction, and loading from multi-section files:
+- Parsing mixed Markdown/XML prompt files with `parseSections`
+- Looking up sections by anchor ID with `getSectionText` (tolerates `-` vs `_` and case differences)
+- Extracting section body text with `sliceSectionContent`
+- Loading named XML sections from a file as a `Prompt` with `loadSection`
+- How anchor IDs are normalized (`normalizeAnchorId`)
+
+**Run it:**
+```bash
+bun examples/sections-usage.ts
+```
+
 ### `openai-example.ts`
 Integration example with OpenAI:
 - System and user prompt templates

--- a/packages/textprompts-ts/examples/prompts/agents.txt
+++ b/packages/textprompts-ts/examples/prompts/agents.txt
@@ -1,0 +1,23 @@
+---
+title: "Agent Personas"
+description: "Collection of system prompt variants for different assistant personas"
+version: "1.0"
+author: "textprompts examples"
+created: "2026-03-19"
+---
+<system id="default">
+You are a helpful assistant. Answer questions clearly and concisely.
+</system>
+
+<system id="expert">
+You are an expert assistant with deep technical knowledge.
+Provide thorough, precise answers with examples where helpful.
+</system>
+
+<system id="concise">
+You are a concise assistant. Reply in one sentence max.
+</system>
+
+<user_template>
+User: {question}
+</user_template>

--- a/packages/textprompts-ts/examples/sections-usage.ts
+++ b/packages/textprompts-ts/examples/sections-usage.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * XML Sections — store multiple prompt variants in one file and extract by ID.
+ *
+ * Section API:
+ *   getSectionText(text, anchorId) → string | null
+ *     Extract the body of a named section from a string.
+ *
+ *   sliceSectionContent(text, section) → string
+ *     Extract the body given a Section object from parseSections().
+ *
+ *   loadSection(path, anchorId, options?) → Promise<Prompt>
+ *     Load a section directly from a file as a Prompt.
+ *
+ *   parseSections(text) → ParseResult
+ *     Parse all sections; each Section has startLine/endLine and
+ *     contentStartLine/contentEndLine but NO content field.
+ *     Use getSectionText() or sliceSectionContent() to get the text.
+ */
+
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { getSectionText, loadSection, parseSections, sliceSectionContent } from "../src/index";
+
+const PROMPTS_DIR = join(import.meta.dir, "prompts");
+const agentsFile = join(PROMPTS_DIR, "agents.txt");
+
+// ── 1. Extract a section from text ──────────────────────────────────────────
+const text = readFileSync(agentsFile, "utf8");
+
+const defaultSystem = getSectionText(text, "default");
+const expertSystem = getSectionText(text, "expert");
+const conciseSystem = getSectionText(text, "concise");
+
+console.log("default:", defaultSystem);
+console.log("expert:", expertSystem);
+console.log("concise:", conciseSystem);
+console.log("missing:", getSectionText(text, "nonexistent")); // null
+
+// ── 2. List all sections and extract each body ───────────────────────────────
+const { sections } = parseSections(text);
+
+console.log("\nAll sections:");
+for (const section of sections) {
+  if (section.kind === "preamble") continue;
+  // Section has no .content field — use sliceSectionContent to get the text
+  const body = sliceSectionContent(text, section);
+  console.log(`  [${section.anchorId}] ${section.heading}: "${body.slice(0, 40)}..."`);
+}
+
+// ── 3. Load a section from a file as a Prompt (supports format/placeholders) ─
+// Works with underscore, hyphen, or either — tag name is the anchor ID
+const userTemplate = await loadSection(agentsFile, "user_template"); // or "user-template"
+const message = userTemplate.prompt.format({ question: "What is TypeScript?" });
+console.log("\nFormatted user message:", message);

--- a/packages/textprompts-ts/package-lock.json
+++ b/packages/textprompts-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "textprompts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "textprompts",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "dependencies": {
         "@iarna/toml": "^2.2.5",
         "fast-glob": "^3.3.2",

--- a/packages/textprompts-ts/package.json
+++ b/packages/textprompts-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "textprompts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "TypeScript companion to textprompts for loading and formatting prompt files.",
   "type": "module",
   "main": "./dist/index.cjs",
@@ -24,10 +24,7 @@
   "sideEffects": false,
   "scripts": {
     "clean": "rm -rf dist",
-    "build": "npm run clean && npm run build:esm && npm run build:cjs && npm run build:types",
-    "build:esm": "bun build src/index.ts src/cli.ts --target node --format esm --outdir dist --entry-naming [name].mjs --external fast-glob --external @iarna/toml --external yaml",
-    "build:cjs": "bun build src/index.ts src/cli.ts --target node --format cjs --outdir dist --entry-naming [name].cjs --external fast-glob --external @iarna/toml --external yaml",
-    "build:types": "tsup src/index.ts src/cli.ts --dts-only --format esm --out-dir dist",
+    "build": "tsup",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "format": "biome format --write .",

--- a/packages/textprompts-ts/src/index.ts
+++ b/packages/textprompts-ts/src/index.ts
@@ -12,7 +12,7 @@ export {
   MissingMetadataError,
   TextPromptsError,
 } from "./errors";
-export { loadPrompt, loadPrompts } from "./loaders";
+export { loadPrompt, loadPrompts, loadSection } from "./loaders";
 export type { PromptMeta } from "./models";
 export { Prompt } from "./models";
 export { parseString } from "./parser";
@@ -21,4 +21,4 @@ export { PromptString } from "./prompt-string";
 export type { FrontMatterFormat } from "./savers";
 export { savePrompt } from "./savers";
 export type { FrontmatterBlock, Link, ParseResult, Section, SectionKind } from "./sections";
-export { generateSlug, injectAnchors, parseSections, renderToc } from "./sections";
+export { generateSlug, getSectionText, injectAnchors, normalizeAnchorId, parseSections, renderToc, sliceSectionContent } from "./sections";

--- a/packages/textprompts-ts/src/loaders.ts
+++ b/packages/textprompts-ts/src/loaders.ts
@@ -1,14 +1,55 @@
-import { lstat } from "node:fs/promises";
+import { lstat, readFile } from "node:fs/promises";
 import fg from "fast-glob";
 
 import { type MetadataMode, resolveMetadataMode } from "./config";
 import { FileMissingError, TextPromptsError } from "./errors";
 import type { Prompt } from "./models";
-import { parseFile } from "./parser";
+import { parseFile, parseString } from "./parser";
+import { getSectionText } from "./sections";
 
 export interface LoadPromptOptions {
   meta?: MetadataMode | string | null;
 }
+
+/**
+ * Load the body text of a specific XML section from a file as a Prompt.
+ *
+ * Useful for storing multiple prompt versions in one file using XML tags:
+ * ```
+ * <system>You are a helpful assistant.</system>
+ * <system id="v2">You are an expert assistant.</system>
+ * ```
+ *
+ * @param path - Path to the prompt file
+ * @param anchorId - The XML tag name or `id` attribute value to extract
+ * @param options - Optional metadata mode configuration
+ */
+export const loadSection = async (
+  path: string,
+  anchorId: string,
+  options: LoadPromptOptions = {},
+): Promise<Prompt> => {
+  try {
+    const stats = await lstat(path);
+    if (!(stats.isFile() || stats.isSymbolicLink())) {
+      throw new FileMissingError(path);
+    }
+  } catch (error) {
+    if (error instanceof FileMissingError) {
+      throw error;
+    }
+    throw new FileMissingError(path);
+  }
+
+  const content = await readFile(path, "utf8");
+  const sectionText = getSectionText(content, anchorId);
+  if (sectionText === null) {
+    throw new TextPromptsError(`Section '${anchorId}' not found in ${path}`);
+  }
+
+  const mode = resolveMetadataMode(options.meta ?? null);
+  return parseString(sectionText, path, mode);
+};
 
 export const loadPrompt = async (
   path: string,

--- a/packages/textprompts-ts/src/sections.ts
+++ b/packages/textprompts-ts/src/sections.ts
@@ -22,6 +22,14 @@ export interface Section {
   level: number;
   startLine: number;
   endLine: number;
+  /** Line where section body content begins (1-indexed, after heading/opening tag). */
+  contentStartLine: number;
+  /** Column offset where content begins on contentStartLine. */
+  contentStartCol: number;
+  /** Line where section body content ends (1-indexed). */
+  contentEndLine: number;
+  /** Column offset where content ends on contentEndLine (-1 means end of line). */
+  contentEndCol: number;
   charCount: number;
   parentIdx: number;
   children: number[];
@@ -230,10 +238,12 @@ export const parseSections = (text: string | Uint8Array): ParseResult => {
         const heading = deriveXMLHeading(block.tagName, block.attrs);
         const parentIdx = parentIndex(stack);
         const level = deriveXMLLevel(result, parentIdx);
+        const explicitId = explicitAnchorFromAttrs(block.attrs);
+        const defaultId = explicitId !== "" ? explicitId : normalizeAnchorId(block.tagName);
         const { anchorId, explicit } = resolveSectionAnchor(
           heading,
           pending,
-          explicitAnchorFromAttrs(block.attrs),
+          defaultId,
           usedAnchorIds,
         );
         const sectionIdx = appendSection(result, {
@@ -244,6 +254,10 @@ export const parseSections = (text: string | Uint8Array): ParseResult => {
           level,
           startLine,
           endLine: block.endLine,
+          contentStartLine: block.startLine,
+          contentStartCol: block.openEndCol,
+          contentEndLine: block.endLine,
+          contentEndCol: block.closeStartCol,
           charCount: 0,
           parentIdx,
           children: [],
@@ -310,6 +324,10 @@ export const parseSections = (text: string | Uint8Array): ParseResult => {
         level: markdownHeading.level,
         startLine,
         endLine: lineNum,
+        contentStartLine: lineNum + 1,
+        contentStartCol: 0,
+        contentEndLine: lineNum,
+        contentEndCol: -1,
         charCount: 0,
         parentIdx,
         children: [],
@@ -365,22 +383,7 @@ export const generateSlug = (heading: string): string => {
   let slug = heading.replace(RE_LINK_INLINE, "$1");
   slug = slug.replace(RE_HTML_TAG, "");
   slug = slug.replace(RE_MD_FORMATTING, "");
-  slug = slug.toLowerCase();
-
-  let out = "";
-  for (const char of slug) {
-    if (/\s/.test(char)) {
-      out += "-";
-    } else if (/^[a-z0-9-]$/.test(char)) {
-      out += char;
-    }
-  }
-
-  while (out.includes("--")) {
-    out = out.replaceAll("--", "-");
-  }
-  out = out.replace(/^-+|-+$/g, "");
-  return out || "section";
+  return normalizeAnchorId(slug);
 };
 
 export const injectAnchors = (text: string | Uint8Array): { text: string; result: ParseResult } => {
@@ -604,7 +607,7 @@ const parseMarkdownHeading = (
   let attrId = "";
   const attrMatch = RE_ATTR_ID.exec(heading);
   if (attrMatch) {
-    attrId = attrMatch[1];
+    attrId = normalizeAnchorId(attrMatch[1]);
     heading = heading.replace(RE_ATTR_ID, "").trim();
   }
 
@@ -728,7 +731,7 @@ const explicitAnchorFromAttrs = (attrs: Record<string, string>): string => {
   for (const key of ["id", "name"]) {
     const value = attrs[key]?.trim() ?? "";
     if (value) {
-      return value;
+      return normalizeAnchorId(value);
     }
   }
   return "";
@@ -736,7 +739,7 @@ const explicitAnchorFromAttrs = (attrs: Record<string, string>): string => {
 
 const extractXMLCommentAnchor = (line: string): string => {
   const match = RE_XML_COMMENT.exec(trimRightCr(line));
-  return match ? match[1] : "";
+  return match ? normalizeAnchorId(match[1]) : "";
 };
 
 const mergePendingAnchor = (
@@ -771,7 +774,7 @@ const uniqueGeneratedAnchor = (base: string, used: Set<string>): string => {
     return root;
   }
   for (let idx = 2; ; idx += 1) {
-    const candidate = `${root}-${idx}`;
+    const candidate = `${root}_${idx}`;
     if (!used.has(candidate)) {
       return candidate;
     }
@@ -847,6 +850,10 @@ const maybeAppendPreamble = (
     level: 0,
     startLine: normalizedStart,
     endLine,
+    contentStartLine: normalizedStart,
+    contentStartCol: 0,
+    contentEndLine: endLine,
+    contentEndCol: lineEndCol(lines, endLine),
     charCount: chars,
     parentIdx: -1,
     children: [],
@@ -904,6 +911,10 @@ const finalizeSection = (
 ): void => {
   const section = result.sections[state.idx];
   section.endLine = endLine;
+  section.contentStartLine = state.contentStartLine;
+  section.contentStartCol = state.contentStartCol;
+  section.contentEndLine = endLine;
+  section.contentEndCol = endCol;
   const { chars, links } = computeWindowStats(
     lines,
     state.contentStartLine,
@@ -1200,4 +1211,98 @@ const findMarkdownHeadingLine = (lines: string[], startLine: number, endLine: nu
   return -1;
 };
 
+/**
+ * Convert any string to a canonical anchor ID:
+ * lowercase, runs of non-alphanumeric characters collapsed to a single
+ * underscore, leading and trailing underscores stripped.
+ *
+ * Applied to all anchor sources: tag names, id attributes, <a id="">,
+ * comment anchors, and markdown {#attr} values.
+ */
+export const normalizeAnchorId = (id: string): string => {
+  const lower = id.toLowerCase();
+  let out = "";
+  for (const char of lower) {
+    if (/^[a-z0-9]$/.test(char)) {
+      out += char;
+    } else if (out.length > 0 && !out.endsWith("_")) {
+      out += "_";
+    }
+  }
+  out = out.replace(/_+$/g, "");
+  return out || "section";
+};
+
 const trimRightCr = (line: string): string => (line.endsWith("\r") ? line.slice(0, -1) : line);
+
+/**
+ * Extract the body text of a specific section by its anchor ID.
+ * Returns null if no section with that anchor ID exists.
+ *
+ * For XML sections: returns the content between the opening and closing tags.
+ * For markdown sections: returns the content after the heading line.
+ *
+ * @example
+ * const text = `<system>\nYou are a helpful assistant.\n</system>`;
+ * getSectionText(text, "system"); // "You are a helpful assistant."
+ */
+export const getSectionText = (text: string | Uint8Array, anchorId: string): string | null => {
+  const source = coerceText(text);
+  const result = parseSections(source);
+  let section = result.sections.find((s) => s.anchorId === anchorId);
+  if (!section) {
+    const normalizedQuery = normalizeAnchorId(anchorId);
+    section = result.sections.find((s) => normalizeAnchorId(s.anchorId) === normalizedQuery);
+  }
+  if (!section) {
+    return null;
+  }
+  return sliceSectionContent(source, section);
+};
+
+/**
+ * Extract the body text of a section given its parsed Section descriptor.
+ * Returns the content between the opening/heading line and closing tag/end.
+ */
+export const sliceSectionContent = (text: string | Uint8Array, section: Section): string => {
+  const source = coerceText(text);
+  const lines = source.split("\n");
+
+  const startLine = section.contentStartLine;
+  const startCol = section.contentStartCol;
+  const endLine = section.contentEndLine;
+  const endCol = section.contentEndCol;
+
+  if (startLine <= 0 || startLine > lines.length) {
+    return "";
+  }
+
+  const parts: string[] = [];
+
+  if (startLine === endLine) {
+    const line = trimRightCr(lines[startLine - 1] ?? "");
+    const from = clamp(startCol, 0, line.length);
+    const to = endCol < 0 ? line.length : clamp(endCol, from, line.length);
+    parts.push(line.slice(from, to));
+  } else {
+    for (let lineNum = startLine; lineNum <= Math.min(endLine, lines.length); lineNum += 1) {
+      let line = trimRightCr(lines[lineNum - 1] ?? "");
+      if (lineNum === startLine && startCol > 0) {
+        line = line.slice(startCol);
+      } else if (lineNum === endLine && endCol >= 0) {
+        line = line.slice(0, endCol);
+      }
+      parts.push(line);
+    }
+  }
+
+  // Trim leading and trailing blank lines, preserve internal whitespace
+  while (parts.length > 0 && parts[0].trim() === "") {
+    parts.shift();
+  }
+  while (parts.length > 0 && parts[parts.length - 1].trim() === "") {
+    parts.pop();
+  }
+
+  return parts.join("\n");
+};

--- a/packages/textprompts-ts/tests/loaders.test.ts
+++ b/packages/textprompts-ts/tests/loaders.test.ts
@@ -5,7 +5,7 @@ import { mkdir, mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 
 import { MetadataMode } from "../src/config";
-import { loadPrompt, loadPrompts } from "../src/loaders";
+import { loadPrompt, loadPrompts, loadSection } from "../src/loaders";
 import { MissingMetadataError, FileMissingError, TextPromptsError } from "../src/errors";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -91,6 +91,23 @@ describe("loaders", () => {
 
     const prompts = await loadPrompts(file1, { meta: MetadataMode.IGNORE });
     expect(prompts.length).toBe(1);
+
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  test("loadSection loads XML sections by normalized anchor id", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "textprompts-test-"));
+    const file = join(tempDir, "agents.txt");
+    await writeFile(
+      file,
+      "<system id=\"expert-mode\">\nBe precise.\n</system>\n\n<user_template>\nUser: {question}\n</user_template>\n",
+    );
+
+    const expert = await loadSection(file, "expert-mode", { meta: MetadataMode.IGNORE });
+    const user = await loadSection(file, "user-template", { meta: MetadataMode.IGNORE });
+
+    expect(String(expert.prompt)).toBe("Be precise.");
+    expect(String(user.prompt)).toBe("User: {question}");
 
     await rm(tempDir, { recursive: true, force: true });
   });

--- a/packages/textprompts-ts/tests/sections.test.ts
+++ b/packages/textprompts-ts/tests/sections.test.ts
@@ -4,10 +4,12 @@ import { fileURLToPath } from "node:url";
 
 import {
   generateSlug,
+  getSectionText,
   injectAnchors,
   parseSections,
   type ParseResult,
   renderToc,
+  sliceSectionContent,
 } from "../src/sections";
 
 interface SharedCase {
@@ -103,17 +105,17 @@ test("parseSections accepts Uint8Array", () => {
 
 test("generateSlug", () => {
   const cases = [
-    ["Hello World", "hello-world"],
-    ["GCP Projects", "gcp-projects"],
-    ["Memory Architecture Design", "memory-architecture-design"],
-    ["**Bold** and *italic*", "bold-and-italic"],
-    ["`code` blocks", "code-blocks"],
-    ["[Link Text](http://example.com)", "link-text"],
-    ["<em>Inline HTML</em>", "inline-html"],
-    ["Multiple   Spaces", "multiple-spaces"],
-    ["Special!@#$%^&*()chars", "specialchars"],
-    ["  Leading/Trailing  ", "leadingtrailing"],
-    ["123 Numbers First", "123-numbers-first"],
+    ["Hello World", "hello_world"],
+    ["GCP Projects", "gcp_projects"],
+    ["Memory Architecture Design", "memory_architecture_design"],
+    ["**Bold** and *italic*", "bold_and_italic"],
+    ["`code` blocks", "code_blocks"],
+    ["[Link Text](http://example.com)", "link_text"],
+    ["<em>Inline HTML</em>", "inline_html"],
+    ["Multiple   Spaces", "multiple_spaces"],
+    ["Special!@#$%^&*()chars", "special_chars"],
+    ["  Leading/Trailing  ", "leading_trailing"],
+    ["123 Numbers First", "123_numbers_first"],
     ["---dashes---", "dashes"],
     ["", "section"],
   ] as const;
@@ -148,9 +150,9 @@ test("injectAnchors is idempotent and markdown only", () => {
   const output = injectAnchors(doc);
   assertParserInvariants(output.result);
 
-  expect(output.text).toContain('<a id="first-section"></a>');
+  expect(output.text).toContain('<a id="first_section"></a>');
   expect(output.text).not.toContain('<a id="instructions"></a>');
-  expect(output.text.match(/<a id="first-section"><\/a>/g)?.length ?? 0).toBe(1);
+  expect(output.text.match(/<a id="first_section"><\/a>/g)?.length ?? 0).toBe(1);
 
   const output2 = injectAnchors(output.text);
   assertParserInvariants(output2.result);
@@ -178,7 +180,7 @@ test("adversarial corpus", () => {
         "<!-- @id:comment-three -->\n" +
         "## Third\n\n" +
         "## Fourth",
-      anchors: ["explicit-one", "attr-two", "comment-three", "fourth"],
+      anchors: ["explicit_one", "attr_two", "comment_three", "fourth"],
       kinds: ["markdown", "markdown", "markdown", "markdown"],
     },
     {
@@ -194,7 +196,7 @@ test("adversarial corpus", () => {
         "Example.\n" +
         "</examples>\n" +
         "</prompt>",
-      anchors: ["prompt", "overview", "worked-examples"],
+      anchors: ["prompt", "overview", "worked_examples"],
       kinds: ["xml", "markdown", "xml"],
     },
   ] as const;
@@ -233,4 +235,23 @@ test("extracts links and line numbers", () => {
     "#local",
   ]);
   expect(result.sections[0].links.map((link) => link.fragment)).toEqual(["frag", "local"]);
+});
+
+test("extracts section bodies with normalized lookups", () => {
+  const doc =
+    "<system id=\"default-agent\">\n" +
+    "You are helpful.\n" +
+    "</system>\n\n" +
+    "<user_template>\n" +
+    "User: {question}\n" +
+    "</user_template>\n";
+
+  const result = parseSections(doc);
+  assertParserInvariants(result);
+
+  expect(sliceSectionContent(doc, result.sections[0])).toBe("You are helpful.");
+  expect(sliceSectionContent(doc, result.sections[1])).toBe("User: {question}");
+  expect(getSectionText(doc, "default-agent")).toBe("You are helpful.");
+  expect(getSectionText(doc, "default_agent")).toBe("You are helpful.");
+  expect(getSectionText(doc, "user-template")).toBe("User: {question}");
 });

--- a/packages/textprompts-ts/tsup.config.ts
+++ b/packages/textprompts-ts/tsup.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: {
+    index: "src/index.ts",
+    cli: "src/cli.ts",
+  },
+  format: ["esm", "cjs"],
+  outExtension({ format }) {
+    return { js: format === "esm" ? ".mjs" : ".cjs" };
+  },
+  external: ["fast-glob", "@iarna/toml", "yaml"],
+  dts: true,
+  sourcemap: false,
+  clean: true,
+  target: "node18",
+  splitting: false,
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "textprompts"
-version = "1.4.0"
+version = "1.5.0"
 description = "Minimal text-based prompt-loader with TOML/YAML front-matter"
 readme = "README.md"
 license = "MIT"

--- a/src/textprompts/sections.py
+++ b/src/textprompts/sections.py
@@ -214,10 +214,13 @@ def parse_sections(text: str | bytes | bytearray) -> ParseResult:
                 heading = _derive_xml_heading(block.tag_name, block.attrs)
                 parent_idx = _parent_index(stack)
                 level = _derive_xml_level(result, parent_idx)
+                explicit_id = _explicit_anchor_from_attrs(block.attrs)
+                if explicit_id == "":
+                    explicit_id = _normalize_anchor_id(block.tag_name)
                 anchor_id, explicit = _resolve_section_anchor(
                     heading,
                     pending,
-                    _explicit_anchor_from_attrs(block.attrs),
+                    explicit_id,
                     used_anchor_ids,
                 )
                 section_idx = _append_section(
@@ -340,20 +343,7 @@ def generate_slug(heading: str) -> str:
     slug = _RE_LINK_INLINE.sub(r"\1", heading)
     slug = _RE_HTML_TAG.sub("", slug)
     slug = _RE_MD_FORMATTING.sub("", slug)
-    slug = slug.lower()
-
-    parts: list[str] = []
-    for char in slug:
-        if char.isspace():
-            parts.append("-")
-        elif char.isascii() and (char.islower() or char.isdigit() or char == "-"):
-            parts.append(char)
-
-    normalized = "".join(parts)
-    while "--" in normalized:
-        normalized = normalized.replace("--", "-")
-    normalized = normalized.strip("-")
-    return normalized or "section"
+    return _normalize_anchor_id(slug)
 
 
 def inject_anchors(text: str | bytes | bytearray) -> tuple[str, ParseResult]:
@@ -535,7 +525,7 @@ def _parse_markdown_heading(line: str) -> tuple[int, str, str, bool]:
     attr_id = ""
     attr_match = _RE_ATTR_ID.search(heading)
     if attr_match is not None:
-        attr_id = attr_match.group(1)
+        attr_id = _normalize_anchor_id(attr_match.group(1))
         heading = _RE_ATTR_ID.sub("", heading).strip()
 
     if heading == "":
@@ -628,13 +618,13 @@ def _explicit_anchor_from_attrs(attrs: dict[str, str]) -> str:
     for key in ("id", "name"):
         value = attrs.get(key, "").strip()
         if value:
-            return value
+            return _normalize_anchor_id(value)
     return ""
 
 
 def _extract_xml_comment_anchor(line: str) -> str:
     match = _RE_XML_COMMENT.match(_trim_right_cr(line))
-    return "" if match is None else match.group(1)
+    return "" if match is None else _normalize_anchor_id(match.group(1))
 
 
 def _merge_pending_anchor(
@@ -666,10 +656,28 @@ def _unique_generated_anchor(base: str, used: set[str]) -> str:
         return candidate
     suffix = 2
     while True:
-        candidate = f"{base or 'section'}-{suffix}"
+        candidate = f"{base or 'section'}_{suffix}"
         if candidate not in used:
             return candidate
         suffix += 1
+
+
+def _normalize_anchor_id(value: str) -> str:
+    out: list[str] = []
+    last_was_underscore = False
+    for char in value.lower():
+        if char.isascii() and char.isalnum():
+            out.append(char)
+            last_was_underscore = False
+        elif out and not last_was_underscore:
+            out.append("_")
+            last_was_underscore = True
+
+    while out and out[-1] == "_":
+        out.pop()
+
+    normalized = "".join(out)
+    return normalized or "section"
 
 
 def _register_anchor(

--- a/testdata/sections/cases.json
+++ b/testdata/sections/cases.json
@@ -13,7 +13,10 @@
           "startLine": 1,
           "endLine": 15,
           "parentIdx": -1,
-          "children": [1, 2],
+          "children": [
+            1,
+            2
+          ],
           "charCount": 132,
           "links": []
         },
@@ -21,7 +24,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Section One",
-          "anchorId": "section-one",
+          "anchorId": "section_one",
           "level": 2,
           "startLine": 5,
           "endLine": 8,
@@ -34,12 +37,14 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Section Two",
-          "anchorId": "section-two",
+          "anchorId": "section_two",
           "level": 2,
           "startLine": 9,
           "endLine": 15,
           "parentIdx": 0,
-          "children": [3],
+          "children": [
+            3
+          ],
           "charCount": 57,
           "links": []
         },
@@ -59,8 +64,8 @@
       ],
       "anchors": {
         "title": 0,
-        "section-one": 1,
-        "section-two": 2,
+        "section_one": 1,
+        "section_two": 2,
         "subsection": 3
       },
       "duplicateAnchors": {},
@@ -90,7 +95,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "First Heading",
-          "anchorId": "first-heading",
+          "anchorId": "first_heading",
           "level": 2,
           "startLine": 5,
           "endLine": 7,
@@ -101,7 +106,7 @@
         }
       ],
       "anchors": {
-        "first-heading": 1
+        "first_heading": 1
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -117,7 +122,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "My Section",
-          "anchorId": "custom-id",
+          "anchorId": "custom_id",
           "level": 2,
           "startLine": 1,
           "endLine": 4,
@@ -128,7 +133,7 @@
         }
       ],
       "anchors": {
-        "custom-id": 0
+        "custom_id": 0
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -144,12 +149,14 @@
           "kind": "xml",
           "tagName": "section",
           "heading": "Data Flow",
-          "anchorId": "data-flow",
+          "anchorId": "data_flow",
           "level": 1,
           "startLine": 1,
           "endLine": 5,
           "parentIdx": -1,
-          "children": [1],
+          "children": [
+            1
+          ],
           "charCount": 24,
           "links": []
         },
@@ -157,7 +164,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Data Flow",
-          "anchorId": "data-flow-2",
+          "anchorId": "data_flow_2",
           "level": 2,
           "startLine": 2,
           "endLine": 5,
@@ -168,8 +175,8 @@
         }
       ],
       "anchors": {
-        "data-flow": 0,
-        "data-flow-2": 1
+        "data_flow": 0,
+        "data_flow_2": 1
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -198,7 +205,7 @@
           "kind": "xml",
           "tagName": "examples",
           "heading": "Worked Example",
-          "anchorId": "worked-example",
+          "anchorId": "examples",
           "level": 1,
           "startLine": 5,
           "endLine": 5,
@@ -210,7 +217,7 @@
       ],
       "anchors": {
         "instructions": 0,
-        "worked-example": 1
+        "examples": 1
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -226,12 +233,15 @@
           "kind": "xml",
           "tagName": "prompt",
           "heading": "Prompt Root",
-          "anchorId": "prompt-root",
+          "anchorId": "prompt_root",
           "level": 1,
           "startLine": 1,
           "endLine": 8,
           "parentIdx": -1,
-          "children": [1, 2],
+          "children": [
+            1,
+            2
+          ],
           "charCount": 95,
           "links": []
         },
@@ -239,7 +249,7 @@
           "kind": "xml",
           "tagName": "section",
           "heading": "Inner One",
-          "anchorId": "inner-one",
+          "anchorId": "inner_one",
           "level": 2,
           "startLine": 2,
           "endLine": 4,
@@ -252,7 +262,7 @@
           "kind": "xml",
           "tagName": "section",
           "heading": "Inner Two",
-          "anchorId": "inner-two",
+          "anchorId": "inner_two",
           "level": 2,
           "startLine": 5,
           "endLine": 7,
@@ -263,9 +273,9 @@
         }
       ],
       "anchors": {
-        "prompt-root": 0,
-        "inner-one": 1,
-        "inner-two": 2
+        "prompt_root": 0,
+        "inner_one": 1,
+        "inner_two": 2
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -281,7 +291,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Heading",
-          "anchorId": "custom-id",
+          "anchorId": "custom_id",
           "level": 2,
           "startLine": 1,
           "endLine": 4,
@@ -292,7 +302,7 @@
         }
       ],
       "anchors": {
-        "custom-id": 0
+        "custom_id": 0
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -321,7 +331,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Real Heading",
-          "anchorId": "real-heading",
+          "anchorId": "real_heading",
           "level": 2,
           "startLine": 7,
           "endLine": 9,
@@ -332,7 +342,7 @@
         }
       ],
       "anchors": {
-        "real-heading": 1
+        "real_heading": 1
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -348,7 +358,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "Heading",
-          "anchorId": "named-anchor",
+          "anchorId": "named_anchor",
           "level": 2,
           "startLine": 1,
           "endLine": 2,
@@ -359,7 +369,7 @@
         }
       ],
       "anchors": {
-        "named-anchor": 0
+        "named_anchor": 0
       },
       "duplicateAnchors": {},
       "frontmatter": null,
@@ -429,7 +439,7 @@
           "kind": "markdown",
           "tagName": "",
           "heading": "First Section",
-          "anchorId": "first-section",
+          "anchorId": "first_section",
           "level": 2,
           "startLine": 6,
           "endLine": 8,
@@ -440,7 +450,7 @@
         }
       ],
       "anchors": {
-        "first-section": 0
+        "first_section": 0
       },
       "duplicateAnchors": {},
       "frontmatter": {

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -108,17 +108,17 @@ def test_parse_sections_accepts_bytes() -> None:
 
 def test_generate_slug() -> None:
     cases = [
-        ("Hello World", "hello-world"),
-        ("GCP Projects", "gcp-projects"),
-        ("Memory Architecture Design", "memory-architecture-design"),
-        ("**Bold** and *italic*", "bold-and-italic"),
-        ("`code` blocks", "code-blocks"),
-        ("[Link Text](http://example.com)", "link-text"),
-        ("<em>Inline HTML</em>", "inline-html"),
-        ("Multiple   Spaces", "multiple-spaces"),
-        ("Special!@#$%^&*()chars", "specialchars"),
-        ("  Leading/Trailing  ", "leadingtrailing"),
-        ("123 Numbers First", "123-numbers-first"),
+        ("Hello World", "hello_world"),
+        ("GCP Projects", "gcp_projects"),
+        ("Memory Architecture Design", "memory_architecture_design"),
+        ("**Bold** and *italic*", "bold_and_italic"),
+        ("`code` blocks", "code_blocks"),
+        ("[Link Text](http://example.com)", "link_text"),
+        ("<em>Inline HTML</em>", "inline_html"),
+        ("Multiple   Spaces", "multiple_spaces"),
+        ("Special!@#$%^&*()chars", "special_chars"),
+        ("  Leading/Trailing  ", "leading_trailing"),
+        ("123 Numbers First", "123_numbers_first"),
         ("---dashes---", "dashes"),
         ("", "section"),
     ]
@@ -152,9 +152,9 @@ def test_inject_anchors_is_idempotent_and_markdown_only() -> None:
     output, result = inject_anchors(doc)
     _assert_parser_invariants(result)
 
-    assert '<a id="first-section"></a>' in output
+    assert '<a id="first_section"></a>' in output
     assert '<a id="instructions"></a>' not in output
-    assert output.count('<a id="first-section"></a>') == 1
+    assert output.count('<a id="first_section"></a>') == 1
 
     output2, result2 = inject_anchors(output)
     _assert_parser_invariants(result2)
@@ -184,7 +184,7 @@ def test_parse_sections_adversarial_corpus() -> None:
                 "## Third\n\n"
                 "## Fourth"
             ),
-            "anchors": ["explicit-one", "attr-two", "comment-three", "fourth"],
+            "anchors": ["explicit_one", "attr_two", "comment_three", "fourth"],
             "kinds": ["markdown", "markdown", "markdown", "markdown"],
         },
         {
@@ -201,7 +201,7 @@ def test_parse_sections_adversarial_corpus() -> None:
                 "</examples>\n"
                 "</prompt>"
             ),
-            "anchors": ["prompt", "overview", "worked-examples"],
+            "anchors": ["prompt", "overview", "worked_examples"],
             "kinds": ["xml", "markdown", "xml"],
         },
     ]


### PR DESCRIPTION
- Section anchors now normalize to underscore IDs, and generic XML sections default to tag-based anchors
